### PR TITLE
Fix LazyInitializationException when updating or deleting reports

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/service/pet/PetReportService.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/service/pet/PetReportService.java
@@ -49,7 +49,7 @@ public class PetReportService {
 
     public PetReport updateReport(Long id, PetReport data, MultipartFile[] files, User user) throws IOException {
         PetReport existing = repository.findById(id).orElseThrow();
-        if(!existing.getUser().equals(user)) return existing;
+        if(!existing.getUser().getId().equals(user.getId())) return existing;
 
         existing.setStatus(data.getStatus());
         existing.setBreed(data.getBreed());
@@ -74,7 +74,7 @@ public class PetReportService {
 
     public void softDelete(Long id, User user){
         PetReport existing = repository.findById(id).orElseThrow();
-        if(!existing.getUser().equals(user)) return;
+        if(!existing.getUser().getId().equals(user.getId())) return;
         existing.setDeleted(true);
         repository.save(existing);
     }


### PR DESCRIPTION
## Summary
- fix user check in PetReportService to compare by ID instead of lazy loading the full User entity

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dc7c8aab88329b961b36eca38a8b7