### PR TITLE
Fix unauthorized image access

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/security/SecurityConfiguration.java
@@ -54,6 +54,7 @@ public class SecurityConfiguration {
             "/swagger-ui.html",
             "/webjars/**",
             "/file/*",
+            "/uploads/**",
             "/error/*",
             "/"
     };


### PR DESCRIPTION
## Summary
- permit `/uploads/**` path in Spring Security so uploaded images are accessible without authentication

## Testing
- `./mvnw -q test` *(fails: cannot open wrapper properties)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dccdda2a083298bfa9a457f063189