### PR TITLE
Add name/date fields and improve popup

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/pet/PetReport.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/pet/PetReport.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.time.LocalDate;
 
 @Data
 @Entity
@@ -29,6 +30,8 @@ public class PetReport {
     private String color;
     private String observation;
     private String phone;
+    private String name;
+    private LocalDate date;
     private Double latitude;
     private Double longitude;
 

--- a/back/src/main/java/com/securitygateway/loginboilerplate/service/pet/PetReportService.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/service/pet/PetReportService.java
@@ -57,6 +57,8 @@ public class PetReportService {
         existing.setColor(data.getColor());
         existing.setObservation(data.getObservation());
         existing.setPhone(data.getPhone());
+        existing.setName(data.getName());
+        existing.setDate(data.getDate());
         existing.setLatitude(data.getLatitude());
         existing.setLongitude(data.getLongitude());
 

--- a/front/src/app/pet/pet-form.component.html
+++ b/front/src/app/pet/pet-form.component.html
@@ -8,6 +8,16 @@
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Nome</mat-label>
+    <input matInput formControlName="name" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Data</mat-label>
+    <input matInput type="date" formControlName="date" />
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="full-width">
     <mat-label>Raça</mat-label>
     <input matInput formControlName="breed" />
   </mat-form-field>

--- a/front/src/app/pet/pet-form.component.ts
+++ b/front/src/app/pet/pet-form.component.ts
@@ -36,6 +36,8 @@ export class PetFormComponent implements OnInit, AfterViewInit {
   constructor(private fb: FormBuilder, private service: PetService, private router: Router, private route: ActivatedRoute) {
     this.form = this.fb.group({
       status: ['LOST', Validators.required],
+      name: ['', Validators.required],
+      date: ['', Validators.required],
       breed: ['', Validators.required],
       size: ['', Validators.required],
       color: ['', Validators.required],

--- a/front/src/app/pet/pet-map.component.html
+++ b/front/src/app/pet/pet-map.component.html
@@ -9,6 +9,8 @@
     <tr>
       <th>Imagem</th>
       <th>Status</th>
+      <th>Nome</th>
+      <th>Data</th>
       <th>Raça</th>
       <th>Tamanho</th>
       <th>Cor</th>
@@ -23,6 +25,8 @@
         <img *ngIf="p.images?.length" [src]="p.images?.[0]" width="50" />
       </td>
       <td>{{p.status}}</td>
+      <td>{{p.name}}</td>
+      <td>{{p.date}}</td>
       <td>{{p.breed}}</td>
       <td>{{p.size}}</td>
       <td>{{p.color}}</td>

--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -17,11 +17,27 @@
   justify-content: center;
   align-items: center;
   z-index: 1000;
+
+  .close-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 24px;
+    cursor: pointer;
+  }
 }
 
 .img-overlay img {
   max-width: 90%;
   max-height: 90%;
+}
+
+.popup-img {
+  max-width: 100px;
+  cursor: pointer;
 }
 
 table.my-pets {

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -69,7 +69,7 @@ export class PetMapComponent implements OnInit {
       if(pet.latitude && pet.longitude){
         const marker = L.marker([pet.latitude, pet.longitude]).addTo(this.map!);
         const img = pet.images && pet.images[0] ? `<img src="${pet.images[0]}" class="popup-img" />` : '';
-        const html = `${img}<div><strong>${pet.status}</strong><br/>${pet.breed || ''}<br/>${pet.color || ''}<br/>${pet.phone || ''}<br/>${pet.observation || ''}</div>`;
+        const html = `${img}<div><strong>${pet.name || ''}</strong><br/>${pet.date || ''}<br/><strong>${pet.status}</strong><br/>${pet.breed || ''}<br/>${pet.color || ''}<br/>${pet.phone || ''}<br/>${pet.observation || ''}</div>`;
         marker.bindPopup(html);
         marker.on('popupopen', () => {
           const el = document.querySelector('.popup-img') as HTMLImageElement;
@@ -79,8 +79,12 @@ export class PetMapComponent implements OnInit {
               if(src){
                 const overlay = document.createElement('div');
                 overlay.className = 'img-overlay';
-                overlay.innerHTML = `<img src="${src}"/>`;
-                overlay.addEventListener('click', () => overlay.remove());
+                overlay.innerHTML = `<button class="close-btn">X</button><img src="${src}"/>`;
+                const btn = overlay.querySelector('.close-btn') as HTMLButtonElement;
+                btn.addEventListener('click', () => overlay.remove());
+                overlay.addEventListener('click', e => {
+                  if(e.target === overlay) overlay.remove();
+                });
                 document.body.appendChild(overlay);
               }
             });
@@ -106,6 +110,8 @@ export class PetMapComponent implements OnInit {
     const files: FileList = event.target.files;
     const data = new FormData();
     data.append('status', p.status);
+    if(p.name) data.append('name', p.name);
+    if(p.date) data.append('date', p.date);
     if(p.breed) data.append('breed', p.breed);
     if(p.size) data.append('size', p.size);
     if(p.color) data.append('color', p.color);

--- a/front/src/app/pet/pet.service.ts
+++ b/front/src/app/pet/pet.service.ts
@@ -6,6 +6,8 @@ import { Observable, map } from 'rxjs';
 export interface PetReport {
   id?: number;
   status: string;
+  name?: string;
+  date?: string;
   breed?: string;
   size?: string;
   color?: string;


### PR DESCRIPTION
## Summary
- store pet name and date on the backend
- include new fields in pet report model and service
- expose name and date on the frontend
- resize popup images and allow fullscreen display with a close button
- show name/date columns on the table and fields in the form

## Testing
- `./mvnw -q test` *(fails: Permission denied)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dce33e2548329b0f44ce56c62dd27