### PR TITLE
Enable cluster map view and center editing pin

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -24,6 +24,7 @@
     "@ngx-translate/http-loader": "^16.0.1",
     "ngx-mask": "^19.0.7",
     "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
@@ -34,6 +35,7 @@
     "@angular/compiler-cli": "^19.0.0",
     "@types/jasmine": "~5.1.0",
     "@types/leaflet": "^1.9.18",
+    "@types/leaflet.markercluster": "^1.5.7",
     "jasmine-core": "~5.4.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/front/src/app/pet/pet-form.component.ts
+++ b/front/src/app/pet/pet-form.component.ts
@@ -91,6 +91,7 @@ export class PetFormComponent implements OnInit, AfterViewInit {
       const [lat, lng] = this.pendingCoords;
       this.pendingCoords = undefined;
       this.marker = L.marker([lat, lng]).addTo(this.map);
+      this.map.setView([lat, lng], 13);
     }
   }
 

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import * as L from 'leaflet';
+import 'leaflet.markercluster';
 import { PetService, PetReport } from './pet.service';
 import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -65,9 +66,10 @@ export class PetMapComponent implements OnInit {
 
   private loadMarkers() {
     if(!this.map) return;
+    const cluster = (L as any).markerClusterGroup();
     for(const pet of this.pets){
       if(pet.latitude && pet.longitude){
-        const marker = L.marker([pet.latitude, pet.longitude]).addTo(this.map!);
+        const marker = L.marker([pet.latitude, pet.longitude]);
         const img = pet.images && pet.images[0] ? `<img src="${pet.images[0]}" class="popup-img" />` : '';
         const html = `${img}<div><strong>${pet.name || ''}</strong><br/>${pet.date || ''}<br/><strong>${pet.status}</strong><br/>${pet.breed || ''}<br/>${pet.color || ''}<br/>${pet.phone || ''}<br/>${pet.observation || ''}</div>`;
         marker.bindPopup(html);
@@ -90,8 +92,10 @@ export class PetMapComponent implements OnInit {
             });
           }
         });
+        cluster.addLayer(marker);
       }
     }
+    this.map.addLayer(cluster);
   }
 
   toggleTable(){

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -3,6 +3,8 @@
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 @import "leaflet/dist/leaflet.css";
+@import "leaflet.markercluster/dist/MarkerCluster.css";
+@import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 /* Esconde o reveal do Edge/IE */
 input[type="password"]::-ms-reveal,
 input[type="password"]::-ms-clear {

--- a/front/tsconfig.app.json
+++ b/front/tsconfig.app.json
@@ -4,7 +4,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": ["leaflet"]
+    "types": ["leaflet", "leaflet.markercluster"]
   },
   "files": [
     "src/main.ts"


### PR DESCRIPTION
## Summary
- center map on marker when editing records
- cluster nearby pins when zooming out
- import MarkerCluster styles globally
- add markercluster dependencies and types

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684dcfb108988329bbd870066f1ce2d5