### PR TITLE
Fix markercluster build issue

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -2,6 +2,19 @@
 
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 19.0.4.
 
+Before running or building the application, install the project dependencies:
+
+```bash
+npm install
+```
+
+If the build complains about missing `leaflet.markercluster` types, make sure the
+package `@types/leaflet.markercluster` is installed:
+
+```bash
+npm install --save-dev @types/leaflet.markercluster
+```
+
 ## Development server
 
 To start a local development server, run:

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -2,9 +2,9 @@
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
-@import "leaflet/dist/leaflet.css";
-@import "leaflet.markercluster/dist/MarkerCluster.css";
-@import "leaflet.markercluster/dist/MarkerCluster.Default.css";
+@import "~leaflet/dist/leaflet.css";
+@import "~leaflet.markercluster/dist/MarkerCluster.css";
+@import "~leaflet.markercluster/dist/MarkerCluster.Default.css";
 /* Esconde o reveal do Edge/IE */
 input[type="password"]::-ms-reveal,
 input[type="password"]::-ms-clear {


### PR DESCRIPTION
## Summary
- import CSS from `node_modules` using the tilde syntax
- add troubleshooting notes for missing deps in README

## Testing
- `npm run test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd0c86ab083298c05339c85aa670f