### PR TITLE
Fix SCSS imports for leaflet marker cluster

### DIFF
--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -2,9 +2,9 @@
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
-@import "~leaflet/dist/leaflet.css";
-@import "~leaflet.markercluster/dist/MarkerCluster.css";
-@import "~leaflet.markercluster/dist/MarkerCluster.Default.css";
+@import "leaflet/dist/leaflet.css";
+@import "leaflet.markercluster/dist/MarkerCluster.css";
+@import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 /* Esconde o reveal do Edge/IE */
 input[type="password"]::-ms-reveal,
 input[type="password"]::-ms-clear {


### PR DESCRIPTION
## Summary
- remove `~` prefix from Leaflet imports in global styles

## Testing
- `npm run build` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1cace208329b63f5cd4088b2995