### PR TITLE
Fix Leaflet markercluster imports

### DIFF
--- a/front/angular.json
+++ b/front/angular.json
@@ -32,6 +32,11 @@
               },
               "src/assets"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "./node_modules"
+              ]
+            },
             "styles": [
               "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
@@ -93,6 +98,11 @@
               },
               "src/assets"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "./node_modules"
+              ]
+            },
             "styles": [
               "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -2,9 +2,9 @@
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
-@import "~leaflet/dist/leaflet.css";
-@import "~leaflet.markercluster/dist/MarkerCluster.css";
-@import "~leaflet.markercluster/dist/MarkerCluster.Default.css";
+@import "leaflet/dist/leaflet.css";
+@import "leaflet.markercluster/dist/MarkerCluster.css";
+@import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 /* Esconde o reveal do Edge/IE */
 input[type="password"]::-ms-reveal,
 input[type="password"]::-ms-clear {

--- a/front/src/types/leaflet.markercluster.d.ts
+++ b/front/src/types/leaflet.markercluster.d.ts
@@ -1,0 +1,1 @@
+declare module 'leaflet.markercluster';


### PR DESCRIPTION
## Summary
- add `stylePreprocessorOptions` so Sass can import from `node_modules`
- stub type declaration for `leaflet.markercluster`

## Testing
- `npm run build` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1cace208329b63f5cd4088b2995