### PR TITLE
Fix leaflet import for Vite

### DIFF
--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import * as L from 'leaflet';
-import 'leaflet.markercluster';
+import 'leaflet.markercluster/dist/leaflet.markercluster.js';
 import { PetService, PetReport } from './pet.service';
 import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';

--- a/front/src/types/leaflet.markercluster.d.ts
+++ b/front/src/types/leaflet.markercluster.d.ts
@@ -1,1 +1,1 @@
-declare module 'leaflet.markercluster';
+declare module 'leaflet.markercluster/dist/leaflet.markercluster.js';


### PR DESCRIPTION
## Summary
- update markercluster import path to the dist file for Vite
- declare correct markercluster module path for TypeScript

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd4c5cc808329a877932bf3333fda