### PR TITLE
Switch to supercluster for map marker clustering

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -8,12 +8,9 @@ Before running or building the application, install the project dependencies:
 npm install
 ```
 
-If the build complains about missing `leaflet.markercluster` types, make sure the
-package `@types/leaflet.markercluster` is installed:
-
-```bash
-npm install --save-dev @types/leaflet.markercluster
-```
+This project uses [supercluster](https://github.com/mapbox/supercluster) to
+cluster map markers. The dependency is installed automatically with the regular
+`npm install` command.
 
 ## Development server
 

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
     "@ngx-translate/http-loader": "^16.0.1",
     "ngx-mask": "^19.0.7",
     "leaflet": "^1.9.4",
-    "leaflet.markercluster": "^1.5.3",
+    "supercluster": "^8.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
@@ -35,7 +35,6 @@
     "@angular/compiler-cli": "^19.0.0",
     "@types/jasmine": "~5.1.0",
     "@types/leaflet": "^1.9.18",
-    "@types/leaflet.markercluster": "^1.5.7",
     "jasmine-core": "~5.4.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/front/src/assets/leaflet.markercluster/MarkerCluster.Default.css
+++ b/front/src/assets/leaflet.markercluster/MarkerCluster.Default.css
@@ -1,4 +1,0 @@
-/* Minimal placeholder for default MarkerCluster appearance */
-.marker-cluster-small { width: 30px; height: 30px; }
-.marker-cluster-medium { width: 40px; height: 40px; }
-.marker-cluster-large { width: 50px; height: 50px; }

--- a/front/src/assets/leaflet.markercluster/MarkerCluster.css
+++ b/front/src/assets/leaflet.markercluster/MarkerCluster.css
@@ -1,7 +1,0 @@
-/* Minimal placeholder for MarkerCluster styles */
-.marker-cluster {
-  background-color: rgba(181, 226, 140, 0.6);
-  border-radius: 20px;
-  color: #000;
-  text-align: center;
-}

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -3,8 +3,6 @@
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 @import "leaflet/dist/leaflet.css";
-@import "./assets/leaflet.markercluster/MarkerCluster.css";
-@import "./assets/leaflet.markercluster/MarkerCluster.Default.css";
 /* Esconde o reveal do Edge/IE */
 input[type="password"]::-ms-reveal,
 input[type="password"]::-ms-clear {
@@ -19,4 +17,14 @@ input[type="password"]::-webkit-textfield-decoration-container {
 /* Garante que não venha nenhuma aparição extra */
 input[type="password"] {
   -webkit-appearance: none;
+}
+
+.cluster-icon {
+  background: rgba(0, 123, 255, 0.6);
+  border-radius: 50%;
+  color: #fff;
+  text-align: center;
+  line-height: 30px;
+  width: 30px;
+  height: 30px;
 }

--- a/front/src/types/leaflet.markercluster.d.ts
+++ b/front/src/types/leaflet.markercluster.d.ts
@@ -1,1 +1,0 @@
-declare module 'leaflet.markercluster';


### PR DESCRIPTION
## Summary
- switch map clustering to the `supercluster` library
- remove references to `leaflet.markercluster`
- update styles with new cluster icon
- document dependency change

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684dd79f10608329ac5f4f791c422668