### PR TITLE
Fix cluster id type when zooming map

### DIFF
--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -111,7 +111,8 @@ export class PetMapComponent implements OnInit {
           })
         });
         marker.on('click', () => {
-          const expansionZoom = this.cluster!.getClusterExpansionZoom(c.id);
+          if (c.id === undefined) return;
+          const expansionZoom = this.cluster!.getClusterExpansionZoom(+c.id);
           this.map!.setView([lat, lng], expansionZoom);
         });
         this.clusterLayer.addLayer(marker);


### PR DESCRIPTION
## Summary
- fix `getClusterExpansionZoom` argument by converting cluster ID to a number

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dd928e9f4832988d2102ab3ebd976