### PR TITLE
Fix cluster update

### DIFF
--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -90,6 +90,7 @@ export class PetMapComponent implements OnInit {
 
   private updateClusters(){
     if(!this.map || !this.cluster) return;
+    this.clusterLayer.clearLayers();
     const bounds = this.map.getBounds();
     const zoom = this.map.getZoom();
     const bbox: [number, number, number, number] = [


### PR DESCRIPTION
## Summary
- ensure markers are refreshed when cluster updates

## Testing
- `npx ng test --watch=false` *(fails: ng not found / network access)*

------
https://chatgpt.com/codex/tasks/task_e_684ddac9950883299000e0fac9bb2441