### PR TITLE
Fix Leaflet icons and popup image overlay

### DIFF
--- a/front/src/app/pet/map-icon.ts
+++ b/front/src/app/pet/map-icon.ts
@@ -1,0 +1,8 @@
+import * as L from 'leaflet';
+
+export const defaultIcon = L.icon({
+  iconUrl: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCI+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTAiIGZpbGw9InJlZCIvPjwvc3ZnPg==',
+  iconSize: [24, 24],
+  iconAnchor: [12, 12],
+  popupAnchor: [0, -12]
+});

--- a/front/src/app/pet/pet-form.component.ts
+++ b/front/src/app/pet/pet-form.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { PetService } from './pet.service';
 import * as L from 'leaflet';
+import { defaultIcon } from './map-icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
@@ -90,7 +91,7 @@ export class PetFormComponent implements OnInit, AfterViewInit {
     if(this.map && this.pendingCoords){
       const [lat, lng] = this.pendingCoords;
       this.pendingCoords = undefined;
-      this.marker = L.marker([lat, lng]).addTo(this.map);
+      this.marker = L.marker([lat, lng], { icon: defaultIcon }).addTo(this.map);
       this.map.setView([lat, lng], 13);
     }
   }
@@ -99,7 +100,7 @@ export class PetFormComponent implements OnInit, AfterViewInit {
     if(this.marker){
       this.map!.removeLayer(this.marker);
     }
-    this.marker = L.marker(ev.latlng).addTo(this.map!);
+    this.marker = L.marker(ev.latlng, { icon: defaultIcon }).addTo(this.map!);
     this.form.patchValue({
       latitude: ev.latlng.lat,
       longitude: ev.latlng.lng

--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -31,12 +31,14 @@
 }
 
 .img-overlay img {
-  max-width: 90%;
-  max-height: 90%;
+  max-width: 80%;
+  max-height: 80%;
+  border: 4px solid #fff;
 }
 
 .popup-img {
-  max-width: 100px;
+  max-width: 220px;
+  max-height: 240px;
   cursor: pointer;
 }
 

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import * as L from 'leaflet';
+import { defaultIcon } from './map-icon';
 import Supercluster from 'supercluster';
 import { PetService, PetReport } from './pet.service';
 import { RouterModule } from '@angular/router';
@@ -119,23 +120,24 @@ export class PetMapComponent implements OnInit {
         this.clusterLayer.addLayer(marker);
       } else {
         const pet = (c.properties as any).pet as PetReport;
-        const marker = L.marker([lat, lng]);
+        const marker = L.marker([lat, lng], { icon: defaultIcon });
         const img = pet.images && pet.images[0] ? `<img src="${pet.images[0]}" class="popup-img" />` : '';
         const html = `${img}<div><strong>${pet.name || ''}</strong><br/>${pet.date || ''}<br/><strong>${pet.status}</strong><br/>${pet.breed || ''}<br/>${pet.color || ''}<br/>${pet.phone || ''}<br/>${pet.observation || ''}</div>`;
         marker.bindPopup(html);
         marker.on('popupopen', () => {
-          const el = document.querySelector('.popup-img') as HTMLImageElement;
-          if(el){
-            el.addEventListener('click', () => {
-              const src = el.getAttribute('src');
-              if(src){
+          const popupEl = marker.getPopup()?.getElement();
+          const imgEl = popupEl?.querySelector('.popup-img') as HTMLImageElement | null;
+          if (imgEl) {
+            imgEl.addEventListener('click', () => {
+              const src = imgEl.getAttribute('src');
+              if (src) {
                 const overlay = document.createElement('div');
                 overlay.className = 'img-overlay';
                 overlay.innerHTML = `<button class="close-btn">X</button><img src="${src}"/>`;
                 const btn = overlay.querySelector('.close-btn') as HTMLButtonElement;
                 btn.addEventListener('click', () => overlay.remove());
                 overlay.addEventListener('click', e => {
-                  if(e.target === overlay) overlay.remove();
+                  if (e.target === overlay) overlay.remove();
                 });
                 document.body.appendChild(overlay);
               }


### PR DESCRIPTION
## Summary
- provide a custom marker icon to avoid 404 errors
- use the custom icon in map and form components
- improve overlay image layout and popup image size
- correctly attach click listener on popup image

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddbf6a488832994f6f4a27f14a0e2