### PR TITLE
Fix overlay image style

### DIFF
--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -16,7 +16,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+  z-index: 10000;
 
   .close-btn {
     position: absolute;
@@ -31,14 +31,16 @@
 }
 
 .img-overlay img {
-  max-width: 80%;
-  max-height: 80%;
+  width: 220px;
+  height: 220px;
+  object-fit: cover;
   border: 4px solid #fff;
 }
 
 .popup-img {
-  max-width: 220px;
-  max-height: 240px;
+  width: 220px;
+  height: 220px;
+  object-fit: cover;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- enforce fixed 220x220 size for pin images
- raise overlay z-index so the image sits above all content

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dde10ecb883298058338b3ff535f9