### PR TITLE
Fix overlay image dimensions

### DIFF
--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -1,4 +1,8 @@
-#map { height: 400px; }
+#map {
+  height: 400px;
+  position: relative;
+  z-index: 0;
+}
 
 .actions {
   margin: 10px 0;
@@ -16,7 +20,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 10000;
+  z-index: 100000;
 
   .close-btn {
     position: absolute;
@@ -31,15 +35,15 @@
 }
 
 .img-overlay img {
-  width: 220px;
-  height: 220px;
+  width: 220.5px;
+  height: 212.89px;
   object-fit: cover;
   border: 4px solid #fff;
 }
 
 .popup-img {
-  width: 220px;
-  height: 220px;
+  width: 220.5px;
+  height: 212.89px;
   object-fit: cover;
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- enforce a fixed size for images displayed in map popups and overlays
- ensure the overlay sits above the map by increasing the z-index
- make the map container positioned to control stacking

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddffe5da08329aa861082f1450fec