### PR TITLE
Improve image overlay in popup

### DIFF
--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -16,11 +16,21 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0,0,0,0.8);
+  background: rgba(0, 0, 0, 0.8);
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 100000;
+
+  .img-card {
+    position: relative;
+    width: 80vw;
+    max-width: 80vw;
+    max-height: 80vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 
   .close-btn {
     position: absolute;
@@ -31,19 +41,21 @@
     color: #fff;
     font-size: 24px;
     cursor: pointer;
+    z-index: 1;
+  }
+
+  img {
+    width: 100%;
+    height: auto;
+    max-height: 80vh;
+    object-fit: contain;
+    border: 4px solid #fff;
   }
 }
 
-.img-overlay img {
-  width: 220.5px;
-  height: 212.89px;
-  object-fit: cover;
-  border: 4px solid #fff;
-}
-
 .popup-img {
-  width: 220.5px;
-  height: 212.89px;
+  width: 240px;
+  height: 220px;
   object-fit: cover;
   cursor: pointer;
 }

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -131,9 +131,16 @@ export class PetMapComponent implements OnInit {
             imgEl.addEventListener('click', () => {
               const src = imgEl.getAttribute('src');
               if (src) {
+                const existing = document.querySelector('.img-overlay');
+                if (existing) existing.remove();
+
                 const overlay = document.createElement('div');
                 overlay.className = 'img-overlay';
-                overlay.innerHTML = `<button class="close-btn">X</button><img src="${src}"/>`;
+                overlay.innerHTML = `
+                  <div class="mat-card img-card">
+                    <button class="close-btn material-icons">close</button>
+                    <img src="${src}" />
+                  </div>`;
                 const btn = overlay.querySelector('.close-btn') as HTMLButtonElement;
                 btn.addEventListener('click', () => overlay.remove());
                 overlay.addEventListener('click', e => {


### PR DESCRIPTION
## Summary
- resize popup image to 240x220
- add material styled overlay for enlarged image and ensure only one overlay at a time

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de4aa35e4832993f7c737c1417944