### PR TITLE
Adjust map popup styles

### DIFF
--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -53,11 +53,23 @@
   }
 }
 
-.popup-img {
-  width: 240px;
-  height: 220px;
-  object-fit: cover;
-  cursor: pointer;
+.pet-popup {
+  max-width: 260px;
+
+  .popup-img {
+    width: 100%;
+    max-height: 200px;
+    object-fit: cover;
+    cursor: pointer;
+  }
+
+  .info-item {
+    margin: 2px 0;
+  }
+
+  .label {
+    font-weight: 600;
+  }
 }
 
 table.my-pets {

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -121,9 +121,21 @@ export class PetMapComponent implements OnInit {
       } else {
         const pet = (c.properties as any).pet as PetReport;
         const marker = L.marker([lat, lng], { icon: defaultIcon });
-        const img = pet.images && pet.images[0] ? `<img src="${pet.images[0]}" class="popup-img" />` : '';
-        const html = `${img}<div><strong>${pet.name || ''}</strong><br/>${pet.date || ''}<br/><strong>${pet.status}</strong><br/>${pet.breed || ''}<br/>${pet.color || ''}<br/>${pet.phone || ''}<br/>${pet.observation || ''}</div>`;
-        marker.bindPopup(html);
+        const img = pet.images && pet.images[0]
+          ? `<img src="${pet.images[0]}" class="popup-img" />`
+          : '';
+        const info = `
+          ${pet.name ? `<div class="info-item"><span class="label">Nome:</span> ${pet.name}</div>` : ''}
+          ${pet.date ? `<div class="info-item"><span class="label">Data:</span> ${pet.date}</div>` : ''}
+          <div class="info-item"><span class="label">Status:</span> ${pet.status}</div>
+          ${pet.breed ? `<div class="info-item"><span class="label">Raça:</span> ${pet.breed}</div>` : ''}
+          ${pet.size ? `<div class="info-item"><span class="label">Tamanho:</span> ${pet.size}</div>` : ''}
+          ${pet.color ? `<div class="info-item"><span class="label">Cor:</span> ${pet.color}</div>` : ''}
+          ${pet.phone ? `<div class="info-item"><span class="label">Telefone:</span> ${pet.phone}</div>` : ''}
+          ${pet.observation ? `<div class="info-item"><span class="label">Observação:</span> ${pet.observation}</div>` : ''}
+        `;
+        const html = `${img}<div class="popup-info">${info}</div>`;
+        marker.bindPopup(html, { className: 'pet-popup', maxWidth: 260 });
         marker.on('popupopen', () => {
           const popupEl = marker.getPopup()?.getElement();
           const imgEl = popupEl?.querySelector('.popup-img') as HTMLImageElement | null;


### PR DESCRIPTION
## Summary
- limit the pet popup width
- scale popup images to the popup
- show labeled fields inside the popup

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de6bbf5fc8329ba1a1f2bc8b638b4