### PR TITLE
Improve marker popup style

### DIFF
--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -57,19 +57,36 @@
 .pet-popup {
   max-width: 260px;
 
+  .popup-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
   .popup-img {
-    width: 100%;
-    max-height: 200px;
+    width: 210px;
+    height: 232px;
     object-fit: cover;
+    border-radius: 8px;
     cursor: pointer;
+    margin-bottom: 8px;
+  }
+
+  .popup-info-card {
+    width: 100%;
+    padding: 4px;
+    background: #fafafa;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 
   .info-item {
     margin: 2px 0;
+    font-size: 14px;
   }
 
   .label {
-    font-weight: 600;
+    font-weight: 700;
   }
 }
 

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -122,7 +122,7 @@ export class PetMapComponent implements OnInit {
         const pet = (c.properties as any).pet as PetReport;
         const marker = L.marker([lat, lng], { icon: defaultIcon });
         const img = pet.images && pet.images[0]
-          ? `<img src="${pet.images[0]}" class="popup-img" />`
+          ? `<img src="${pet.images[0]}" class="popup-img" style="width:210px;height:232px;" />`
           : '';
         const info = `
           ${pet.name ? `<div class="info-item"><span class="label">Nome:</span> ${pet.name}</div>` : ''}
@@ -134,7 +134,12 @@ export class PetMapComponent implements OnInit {
           ${pet.phone ? `<div class="info-item"><span class="label">Telefone:</span> ${pet.phone}</div>` : ''}
           ${pet.observation ? `<div class="info-item"><span class="label">Observação:</span> ${pet.observation}</div>` : ''}
         `;
-        const html = `${img}<div class="popup-info">${info}</div>`;
+        const html = `
+          <div class="popup-card">
+            ${img}
+            <div class="popup-info-card">${info}</div>
+          </div>
+        `;
         marker.bindPopup(html, { className: 'pet-popup', maxWidth: 260 });
         marker.on('popupopen', () => {
           const popupEl = marker.getPopup()?.getElement();


### PR DESCRIPTION
## Summary
- update popup HTML structure with subcard styling and fixed image size
- add SCSS styles for popup card and info

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de9b23b188329bf0b69d5a1325b7c