### PR TITLE
Add Brazilian date and i18n labels

### DIFF
--- a/front/src/app/pet/pet-form.component.html
+++ b/front/src/app/pet/pet-form.component.html
@@ -1,44 +1,44 @@
 <form class="pet-form" [formGroup]="form" (ngSubmit)="submit()">
   <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Status</mat-label>
+    <mat-label>{{ 'PET.STATUS' | translate }}</mat-label>
     <mat-select formControlName="status">
-      <mat-option value="LOST">Perdido</mat-option>
-      <mat-option value="FOUND">Encontrado</mat-option>
+      <mat-option value="LOST">{{ 'PET.STATUS_LOST' | translate }}</mat-option>
+      <mat-option value="FOUND">{{ 'PET.STATUS_FOUND' | translate }}</mat-option>
     </mat-select>
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Nome</mat-label>
+    <mat-label>{{ 'PET.NAME' | translate }}</mat-label>
     <input matInput formControlName="name" />
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Data</mat-label>
+    <mat-label>{{ 'PET.DATE' | translate }}</mat-label>
     <input matInput type="date" formControlName="date" />
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Raça</mat-label>
+    <mat-label>{{ 'PET.BREED' | translate }}</mat-label>
     <input matInput formControlName="breed" />
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Tamanho</mat-label>
+    <mat-label>{{ 'PET.SIZE' | translate }}</mat-label>
     <input matInput formControlName="size" />
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Cor</mat-label>
+    <mat-label>{{ 'PET.COLOR' | translate }}</mat-label>
     <input matInput formControlName="color" />
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Observação</mat-label>
+    <mat-label>{{ 'PET.OBSERVATION' | translate }}</mat-label>
     <textarea matInput formControlName="observation"></textarea>
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Telefone</mat-label>
+    <mat-label>{{ 'PET.PHONE' | translate }}</mat-label>
     <input matInput formControlName="phone" />
   </mat-form-field>
 
@@ -47,5 +47,5 @@
 
   <input type="file" multiple (change)="onFile($event)" />
 
-  <button mat-raised-button color="primary" type="submit" [disabled]="!canSave()">Salvar</button>
+  <button mat-raised-button color="primary" type="submit" [disabled]="!canSave()">{{ 'PET.SAVE' | translate }}</button>
 </form>

--- a/front/src/app/pet/pet-form.component.ts
+++ b/front/src/app/pet/pet-form.component.ts
@@ -9,6 +9,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-pet-form',
@@ -20,7 +21,8 @@ import { MatSelectModule } from '@angular/material/select';
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
-    MatSelectModule
+    MatSelectModule,
+    TranslateModule
   ],
   templateUrl: './pet-form.component.html',
   styleUrls: ['./pet-form.component.scss']

--- a/front/src/app/pet/pet-map.component.html
+++ b/front/src/app/pet/pet-map.component.html
@@ -1,22 +1,22 @@
 <div class="actions" *ngIf="loggedIn">
-  <a mat-raised-button color="primary" routerLink="/pet/new">Adicionar pet</a>
-  <button mat-raised-button color="accent" (click)="toggleTable()">Meus registros</button>
+  <a mat-raised-button color="primary" routerLink="/pet/new">{{ 'PET.ADD' | translate }}</a>
+  <button mat-raised-button color="accent" (click)="toggleTable()">{{ 'PET.MY_RECORDS' | translate }}</button>
 </div>
 <div id="map"></div>
 
 <table *ngIf="showTable" class="my-pets">
   <thead>
     <tr>
-      <th>Imagem</th>
-      <th>Status</th>
-      <th>Nome</th>
-      <th>Data</th>
-      <th>Raça</th>
-      <th>Tamanho</th>
-      <th>Cor</th>
-      <th>Observação</th>
-      <th>Telefone</th>
-      <th>Ações</th>
+      <th>{{ 'PET.IMAGE' | translate }}</th>
+      <th>{{ 'PET.STATUS' | translate }}</th>
+      <th>{{ 'PET.NAME' | translate }}</th>
+      <th>{{ 'PET.DATE' | translate }}</th>
+      <th>{{ 'PET.BREED' | translate }}</th>
+      <th>{{ 'PET.SIZE' | translate }}</th>
+      <th>{{ 'PET.COLOR' | translate }}</th>
+      <th>{{ 'PET.OBSERVATION' | translate }}</th>
+      <th>{{ 'PET.PHONE' | translate }}</th>
+      <th>{{ 'PET.ACTIONS' | translate }}</th>
     </tr>
   </thead>
   <tbody>
@@ -26,15 +26,15 @@
       </td>
       <td>{{p.status}}</td>
       <td>{{p.name}}</td>
-      <td>{{p.date}}</td>
+      <td>{{p.date | date:'dd/MM/yyyy'}}</td>
       <td>{{p.breed}}</td>
       <td>{{p.size}}</td>
       <td>{{p.color}}</td>
       <td>{{p.observation}}</td>
       <td>{{p.phone}}</td>
       <td>
-        <a mat-button color="primary" [routerLink]="['/pet', p.id, 'edit']">Editar</a>
-        <button mat-button color="warn" (click)="remove(p)">Remover</button>
+        <a mat-button color="primary" [routerLink]="['/pet', p.id, 'edit']">{{ 'PET.EDIT' | translate }}</a>
+        <button mat-button color="warn" (click)="remove(p)">{{ 'PET.REMOVE' | translate }}</button>
       </td>
     </tr>
   </tbody>

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -6,11 +6,12 @@ import Supercluster from 'supercluster';
 import { PetService, PetReport } from './pet.service';
 import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-pet-map',
   standalone: true,
-  imports: [CommonModule, RouterModule, MatButtonModule],
+  imports: [CommonModule, RouterModule, MatButtonModule, TranslateModule],
   templateUrl: './pet-map.component.html',
   styleUrls: ['./pet-map.component.scss']
 })
@@ -22,7 +23,7 @@ export class PetMapComponent implements OnInit {
   myPets: PetReport[] = [];
   showTable = false;
 
-  constructor(private service: PetService) {}
+  constructor(private service: PetService, private translate: TranslateService) {}
 
   get loggedIn(): boolean {
     return !!localStorage.getItem('accessToken');
@@ -125,14 +126,14 @@ export class PetMapComponent implements OnInit {
           ? `<img src="${pet.images[0]}" class="popup-img" style="width:210px;height:232px;" />`
           : '';
         const info = `
-          ${pet.name ? `<div class="info-item"><span class="label">Nome:</span> ${pet.name}</div>` : ''}
-          ${pet.date ? `<div class="info-item"><span class="label">Data:</span> ${pet.date}</div>` : ''}
-          <div class="info-item"><span class="label">Status:</span> ${pet.status}</div>
-          ${pet.breed ? `<div class="info-item"><span class="label">Raça:</span> ${pet.breed}</div>` : ''}
-          ${pet.size ? `<div class="info-item"><span class="label">Tamanho:</span> ${pet.size}</div>` : ''}
-          ${pet.color ? `<div class="info-item"><span class="label">Cor:</span> ${pet.color}</div>` : ''}
-          ${pet.phone ? `<div class="info-item"><span class="label">Telefone:</span> ${pet.phone}</div>` : ''}
-          ${pet.observation ? `<div class="info-item"><span class="label">Observação:</span> ${pet.observation}</div>` : ''}
+          ${pet.name ? `<div class="info-item"><span class="label">${this.translate.instant('PET.NAME')}:</span> ${pet.name}</div>` : ''}
+          ${pet.date ? `<div class="info-item"><span class="label">${this.translate.instant('PET.DATE')}:</span> ${new Date(pet.date).toLocaleDateString('pt-BR')}</div>` : ''}
+          <div class="info-item"><span class="label">${this.translate.instant('PET.STATUS')}:</span> ${pet.status}</div>
+          ${pet.breed ? `<div class="info-item"><span class="label">${this.translate.instant('PET.BREED')}:</span> ${pet.breed}</div>` : ''}
+          ${pet.size ? `<div class="info-item"><span class="label">${this.translate.instant('PET.SIZE')}:</span> ${pet.size}</div>` : ''}
+          ${pet.color ? `<div class="info-item"><span class="label">${this.translate.instant('PET.COLOR')}:</span> ${pet.color}</div>` : ''}
+          ${pet.phone ? `<div class="info-item"><span class="label">${this.translate.instant('PET.PHONE')}:</span> ${pet.phone}</div>` : ''}
+          ${pet.observation ? `<div class="info-item"><span class="label">${this.translate.instant('PET.OBSERVATION')}:</span> ${pet.observation}</div>` : ''}
         `;
         const html = `
           <div class="popup-card">

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -88,6 +88,26 @@
         "PORTUGUESE": "Portuguese",
         "ENGLISH": "English"
       }
-        
+
+      ,"PET": {
+        "ADD": "Add pet",
+        "MY_RECORDS": "My records",
+        "IMAGE": "Image",
+        "STATUS": "Status",
+        "NAME": "Name",
+        "DATE": "Date",
+        "BREED": "Breed",
+        "SIZE": "Size",
+        "COLOR": "Color",
+        "OBSERVATION": "Observation",
+        "PHONE": "Phone",
+        "ACTIONS": "Actions",
+        "EDIT": "Edit",
+        "REMOVE": "Remove"
+        ,"STATUS_LOST": "Lost"
+        ,"STATUS_FOUND": "Found"
+        ,"SAVE": "Save"
+      }
+
   }
   

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -95,5 +95,25 @@
       "PORTUGUESE": "Português",
       "ENGLISH": "Inglês"
     }
+
+    ,"PET": {
+      "ADD": "Adicionar pet",
+      "MY_RECORDS": "Meus registros",
+      "IMAGE": "Imagem",
+      "STATUS": "Status",
+      "NAME": "Nome",
+      "DATE": "Data",
+      "BREED": "Raça",
+      "SIZE": "Tamanho",
+      "COLOR": "Cor",
+      "OBSERVATION": "Observação",
+      "PHONE": "Telefone",
+      "ACTIONS": "Ações",
+      "EDIT": "Editar",
+      "REMOVE": "Remover",
+      "STATUS_LOST": "Perdido",
+      "STATUS_FOUND": "Encontrado",
+      "SAVE": "Salvar"
+    }
   }
   


### PR DESCRIPTION
## Summary
- enable i18n in pet map and form
- translate table and popup labels
- show pet dates in dd/MM/yyyy
- add English and Portuguese translation keys

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw test` *(fails: missing Maven wrapper files)*

------
https://chatgpt.com/codex/tasks/task_e_684df0dc4a708329bb27534a817ee4d9