### PR TITLE
Show my pets in dialog

### DIFF
--- a/front/src/app/pet/my-pets-dialog.component.html
+++ b/front/src/app/pet/my-pets-dialog.component.html
@@ -1,0 +1,38 @@
+<mat-card>
+  <mat-card-title>{{ 'PET.MY_RECORDS' | translate }}</mat-card-title>
+  <mat-card-content>
+    <table class="my-pets">
+      <thead>
+        <tr>
+          <th>{{ 'PET.IMAGE' | translate }}</th>
+          <th>{{ 'PET.STATUS' | translate }}</th>
+          <th>{{ 'PET.NAME' | translate }}</th>
+          <th>{{ 'PET.DATE' | translate }}</th>
+          <th>{{ 'PET.BREED' | translate }}</th>
+          <th>{{ 'PET.SIZE' | translate }}</th>
+          <th>{{ 'PET.COLOR' | translate }}</th>
+          <th>{{ 'PET.OBSERVATION' | translate }}</th>
+          <th>{{ 'PET.PHONE' | translate }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let p of data.pets">
+          <td>
+            <img *ngIf="p.images?.length" [src]="p.images?.[0]" width="50" />
+          </td>
+          <td>{{ p.status }}</td>
+          <td>{{ p.name }}</td>
+          <td>{{ p.date | date:'dd/MM/yyyy' }}</td>
+          <td>{{ p.breed }}</td>
+          <td>{{ p.size }}</td>
+          <td>{{ p.color }}</td>
+          <td>{{ p.observation }}</td>
+          <td>{{ p.phone }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </mat-card-content>
+  <mat-card-actions align="end">
+    <button mat-button (click)="close()">{{ 'COMMON.CLOSE' | translate }}</button>
+  </mat-card-actions>
+</mat-card>

--- a/front/src/app/pet/my-pets-dialog.component.scss
+++ b/front/src/app/pet/my-pets-dialog.component.scss
@@ -1,0 +1,10 @@
+table.my-pets {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+table.my-pets th,
+table.my-pets td {
+  text-align: center;
+  padding: 4px;
+}

--- a/front/src/app/pet/my-pets-dialog.component.ts
+++ b/front/src/app/pet/my-pets-dialog.component.ts
@@ -1,0 +1,33 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { TranslateModule } from '@ngx-translate/core';
+import { RouterModule } from '@angular/router';
+import { PetReport } from './pet.service';
+
+@Component({
+  selector: 'app-my-pets-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatCardModule,
+    RouterModule,
+    TranslateModule
+  ],
+  templateUrl: './my-pets-dialog.component.html',
+  styleUrls: ['./my-pets-dialog.component.scss']
+})
+export class MyPetsDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<MyPetsDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { pets: PetReport[] }
+  ) {}
+
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/front/src/app/pet/pet-map.component.html
+++ b/front/src/app/pet/pet-map.component.html
@@ -1,41 +1,6 @@
 <div class="actions" *ngIf="loggedIn">
   <a mat-raised-button color="primary" routerLink="/pet/new">{{ 'PET.ADD' | translate }}</a>
-  <button mat-raised-button color="accent" (click)="toggleTable()">{{ 'PET.MY_RECORDS' | translate }}</button>
+  <button mat-raised-button color="accent" (click)="openMyPets()">{{ 'PET.MY_RECORDS' | translate }}</button>
 </div>
 <div id="map"></div>
 
-<table *ngIf="showTable" class="my-pets">
-  <thead>
-    <tr>
-      <th>{{ 'PET.IMAGE' | translate }}</th>
-      <th>{{ 'PET.STATUS' | translate }}</th>
-      <th>{{ 'PET.NAME' | translate }}</th>
-      <th>{{ 'PET.DATE' | translate }}</th>
-      <th>{{ 'PET.BREED' | translate }}</th>
-      <th>{{ 'PET.SIZE' | translate }}</th>
-      <th>{{ 'PET.COLOR' | translate }}</th>
-      <th>{{ 'PET.OBSERVATION' | translate }}</th>
-      <th>{{ 'PET.PHONE' | translate }}</th>
-      <th>{{ 'PET.ACTIONS' | translate }}</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr *ngFor="let p of myPets">
-      <td>
-        <img *ngIf="p.images?.length" [src]="p.images?.[0]" width="50" />
-      </td>
-      <td>{{p.status}}</td>
-      <td>{{p.name}}</td>
-      <td>{{p.date | date:'dd/MM/yyyy'}}</td>
-      <td>{{p.breed}}</td>
-      <td>{{p.size}}</td>
-      <td>{{p.color}}</td>
-      <td>{{p.observation}}</td>
-      <td>{{p.phone}}</td>
-      <td>
-        <a mat-button color="primary" [routerLink]="['/pet', p.id, 'edit']">{{ 'PET.EDIT' | translate }}</a>
-        <button mat-button color="warn" (click)="remove(p)">{{ 'PET.REMOVE' | translate }}</button>
-      </td>
-    </tr>
-  </tbody>
-</table>

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -6,12 +6,14 @@ import Supercluster from 'supercluster';
 import { PetService, PetReport } from './pet.service';
 import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { MyPetsDialogComponent } from './my-pets-dialog.component';
 
 @Component({
   selector: 'app-pet-map',
   standalone: true,
-  imports: [CommonModule, RouterModule, MatButtonModule, TranslateModule],
+  imports: [CommonModule, RouterModule, MatButtonModule, MatDialogModule, TranslateModule],
   templateUrl: './pet-map.component.html',
   styleUrls: ['./pet-map.component.scss']
 })
@@ -21,9 +23,12 @@ export class PetMapComponent implements OnInit {
   private clusterLayer = L.layerGroup();
   pets: PetReport[] = [];
   myPets: PetReport[] = [];
-  showTable = false;
 
-  constructor(private service: PetService, private translate: TranslateService) {}
+  constructor(
+    private service: PetService,
+    private translate: TranslateService,
+    private dialog: MatDialog
+  ) {}
 
   get loggedIn(): boolean {
     return !!localStorage.getItem('accessToken');
@@ -174,8 +179,12 @@ export class PetMapComponent implements OnInit {
     }
   }
 
-  toggleTable(){
-    this.showTable = !this.showTable;
+  openMyPets() {
+    this.dialog.open(MyPetsDialogComponent, {
+      width: '90%',
+      maxWidth: '600px',
+      data: { pets: this.myPets }
+    });
   }
 
   remove(p: PetReport){


### PR DESCRIPTION
## Summary
- show "My records" in a dialog instead of a table
- add `MyPetsDialogComponent` with a table wrapped in a mat-card
- wire `openMyPets()` button to open the dialog

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df3787934832987c4e5dc493b561b