### PR TITLE
Enable pet form as modal popup

### DIFF
--- a/front/src/app/pet/my-pets-dialog.component.html
+++ b/front/src/app/pet/my-pets-dialog.component.html
@@ -30,7 +30,7 @@
           <td>{{ p.observation }}</td>
           <td>{{ p.phone }}</td>
           <td>
-            <a mat-button color="primary" [routerLink]="['/pet', p.id, 'edit']">{{ 'PET.EDIT' | translate }}</a>
+            <button mat-button color="primary" (click)="edit(p)">{{ 'PET.EDIT' | translate }}</button>
             <button mat-button color="warn" (click)="remove(p)">{{ 'PET.REMOVE' | translate }}</button>
           </td>
         </tr>

--- a/front/src/app/pet/my-pets-dialog.component.ts
+++ b/front/src/app/pet/my-pets-dialog.component.ts
@@ -4,7 +4,6 @@ import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/materia
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { TranslateModule } from '@ngx-translate/core';
-import { RouterModule } from '@angular/router';
 import { PetReport, PetService } from './pet.service';
 
 @Component({
@@ -15,7 +14,6 @@ import { PetReport, PetService } from './pet.service';
     MatDialogModule,
     MatButtonModule,
     MatCardModule,
-    RouterModule,
     TranslateModule
   ],
   templateUrl: './my-pets-dialog.component.html',
@@ -37,5 +35,10 @@ export class MyPetsDialogComponent {
     this.service.delete(p.id).subscribe(() => {
       this.data.pets = this.data.pets.filter(m => m.id !== p.id);
     });
+  }
+
+  edit(p: PetReport) {
+    if (!p.id) return;
+    this.dialogRef.close({ edit: p.id });
   }
 }

--- a/front/src/app/pet/pet-form.component.html
+++ b/front/src/app/pet/pet-form.component.html
@@ -48,4 +48,5 @@
   <input type="file" multiple (change)="onFile($event)" />
 
   <button mat-raised-button color="primary" type="submit" [disabled]="!canSave()">{{ 'PET.SAVE' | translate }}</button>
+  <button mat-button type="button" (click)="close()" *ngIf="dialogRef">{{ 'COMMON.CLOSE' | translate }}</button>
 </form>

--- a/front/src/app/pet/pet-map.component.html
+++ b/front/src/app/pet/pet-map.component.html
@@ -1,5 +1,5 @@
 <div class="actions" *ngIf="loggedIn">
-  <a mat-raised-button color="primary" routerLink="/pet/new">{{ 'PET.ADD' | translate }}</a>
+  <button mat-raised-button color="primary" (click)="openPetForm()">{{ 'PET.ADD' | translate }}</button>
   <button mat-raised-button color="accent" (click)="openMyPets()">{{ 'PET.MY_RECORDS' | translate }}</button>
 </div>
 <div id="map"></div>

--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -65,7 +65,7 @@
 
   .popup-img {
     width: 210px;
-    height: 232px;
+    height: 260px;
     object-fit: cover;
     border-radius: 8px;
     cursor: pointer;

--- a/front/src/app/pet/pet-popup.component.scss
+++ b/front/src/app/pet/pet-popup.component.scss
@@ -6,7 +6,7 @@
 
 .popup-img {
   width: 210px;
-  height: 232px;
+  height: 260px;
   object-fit: cover;
   border-radius: 8px;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- allow taller popup images
- add optional popup mode to pet form
- open the pet form as a dialog from the map
- trigger editing from "my pets" dialog via the new popup

## Testing
- `npm test --prefix front --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df77524348329bcac1d2be1b548b2