### PR TITLE
Fix dialogRef visibility

### DIFF
--- a/front/src/app/pet/pet-form.component.ts
+++ b/front/src/app/pet/pet-form.component.ts
@@ -42,7 +42,7 @@ export class PetFormComponent implements OnInit, AfterViewInit {
     private service: PetService,
     private router: Router,
     private route: ActivatedRoute,
-    @Optional() private dialogRef?: MatDialogRef<PetFormComponent>,
+    @Optional() public dialogRef?: MatDialogRef<PetFormComponent>,
     @Inject(MAT_DIALOG_DATA) @Optional() data?: { id?: number }
   ) {
     this.form = this.fb.group({


### PR DESCRIPTION
## Summary
- make `dialogRef` public so PetFormComponent template can check it

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df8ef8d008329969fd42fbcd8c777