### PR TITLE
Add close button and responsive pet form

### DIFF
--- a/front/src/app/pet/pet-form.component.html
+++ b/front/src/app/pet/pet-form.component.html
@@ -1,52 +1,57 @@
 <form class="pet-form" [formGroup]="form" (ngSubmit)="submit()">
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'PET.STATUS' | translate }}</mat-label>
-    <mat-select formControlName="status">
-      <mat-option value="LOST">{{ 'PET.STATUS_LOST' | translate }}</mat-option>
-      <mat-option value="FOUND">{{ 'PET.STATUS_FOUND' | translate }}</mat-option>
-    </mat-select>
-  </mat-form-field>
+  <button mat-icon-button type="button" class="close-btn" (click)="close()" *ngIf="dialogRef">
+    <mat-icon>close</mat-icon>
+  </button>
+  <div class="form-columns">
+    <div class="column">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PET.STATUS' | translate }}</mat-label>
+        <mat-select formControlName="status">
+          <mat-option value="LOST">{{ 'PET.STATUS_LOST' | translate }}</mat-option>
+          <mat-option value="FOUND">{{ 'PET.STATUS_FOUND' | translate }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PET.NAME' | translate }}</mat-label>
+        <input matInput formControlName="name" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PET.DATE' | translate }}</mat-label>
+        <input matInput type="date" formControlName="date" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PET.BREED' | translate }}</mat-label>
+        <input matInput formControlName="breed" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PET.SIZE' | translate }}</mat-label>
+        <input matInput formControlName="size" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PET.COLOR' | translate }}</mat-label>
+        <input matInput formControlName="color" />
+      </mat-form-field>
+    </div>
+    <div class="column">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PET.OBSERVATION' | translate }}</mat-label>
+        <textarea matInput formControlName="observation"></textarea>
+      </mat-form-field>
 
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'PET.NAME' | translate }}</mat-label>
-    <input matInput formControlName="name" />
-  </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>{{ 'PET.PHONE' | translate }}</mat-label>
+        <input matInput formControlName="phone" />
+      </mat-form-field>
 
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'PET.DATE' | translate }}</mat-label>
-    <input matInput type="date" formControlName="date" />
-  </mat-form-field>
+      <label class="address-label">{{ 'PET.SELECT_ADDRESS' | translate }}</label>
+      <div id="selectMap" class="map"></div>
+      <div class="coords">Lat: {{form.value.latitude}} - Lng: {{form.value.longitude}}</div>
 
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'PET.BREED' | translate }}</mat-label>
-    <input matInput formControlName="breed" />
-  </mat-form-field>
-
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'PET.SIZE' | translate }}</mat-label>
-    <input matInput formControlName="size" />
-  </mat-form-field>
-
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'PET.COLOR' | translate }}</mat-label>
-    <input matInput formControlName="color" />
-  </mat-form-field>
-
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'PET.OBSERVATION' | translate }}</mat-label>
-    <textarea matInput formControlName="observation"></textarea>
-  </mat-form-field>
-
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>{{ 'PET.PHONE' | translate }}</mat-label>
-    <input matInput formControlName="phone" />
-  </mat-form-field>
-
-  <div id="selectMap" class="map"></div>
-  <div class="coords">Lat: {{form.value.latitude}} - Lng: {{form.value.longitude}}</div>
-
-  <input type="file" multiple (change)="onFile($event)" />
-
-  <button mat-raised-button color="primary" type="submit" [disabled]="!canSave()">{{ 'PET.SAVE' | translate }}</button>
-  <button mat-button type="button" (click)="close()" *ngIf="dialogRef">{{ 'COMMON.CLOSE' | translate }}</button>
+      <input type="file" multiple (change)="onFile($event)" />
+    </div>
+  </div>
+  <div class="actions">
+    <button mat-raised-button color="primary" type="submit" [disabled]="!canSave()">{{ 'PET.SAVE' | translate }}</button>
+    <button mat-button type="button" (click)="close()" *ngIf="dialogRef">{{ 'COMMON.CLOSE' | translate }}</button>
+  </div>
 </form>

--- a/front/src/app/pet/pet-form.component.scss
+++ b/front/src/app/pet/pet-form.component.scss
@@ -1,9 +1,31 @@
 .pet-form {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-width: 500px;
+  max-width: 900px;
   margin: auto;
+}
+
+.close-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+}
+
+.form-columns {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+@media (min-width: 768px) {
+  .form-columns {
+    flex-direction: row;
+  }
+  .form-columns .column {
+    flex: 1;
+  }
 }
 
 .map {
@@ -14,6 +36,18 @@
   margin-bottom: 10px;
 }
 
+.address-label {
+  font-weight: 600;
+  margin-bottom: 4px;
+  display: block;
+}
+
 .full-width {
   width: 100%;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
 }

--- a/front/src/app/pet/pet-form.component.ts
+++ b/front/src/app/pet/pet-form.component.ts
@@ -10,6 +10,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
+import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
@@ -23,6 +24,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MatInputModule,
     MatButtonModule,
     MatSelectModule,
+    MatIconModule,
     TranslateModule
   ],
   templateUrl: './pet-form.component.html',

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -101,6 +101,7 @@
         "COLOR": "Color",
         "OBSERVATION": "Observation",
         "PHONE": "Phone",
+        "SELECT_ADDRESS": "Select the address where the pet was lost or found",
         "ACTIONS": "Actions",
         "EDIT": "Edit",
         "REMOVE": "Remove"

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -108,6 +108,7 @@
       "COLOR": "Cor",
       "OBSERVATION": "Observação",
       "PHONE": "Telefone",
+      "SELECT_ADDRESS": "Selecione o endereço que o pet foi perdido ou encontrado",
       "ACTIONS": "Ações",
       "EDIT": "Editar",
       "REMOVE": "Remover",


### PR DESCRIPTION
## Summary
- adjust pet form for two-column layout on desktop
- keep single column layout for mobile
- add close button inside pet form dialog
- add internationalized label for selecting pet address
- update translations

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfac664808329988489d8028e5e95