### PR TITLE
Add image preview and loading spinner for pet form

### DIFF
--- a/front/src/app/pet/pet-form.component.html
+++ b/front/src/app/pet/pet-form.component.html
@@ -1,4 +1,7 @@
 <form class="pet-form" [formGroup]="form" (ngSubmit)="submit()">
+  <div class="loading-overlay" *ngIf="loading">
+    <mat-progress-spinner mode="indeterminate"></mat-progress-spinner>
+  </div>
   <button mat-icon-button type="button" class="close-btn" (click)="close()" *ngIf="dialogRef">
     <mat-icon>close</mat-icon>
   </button>
@@ -48,6 +51,9 @@
       <div class="coords">Lat: {{form.value.latitude}} - Lng: {{form.value.longitude}}</div>
 
       <input type="file" multiple (change)="onFile($event)" />
+      <div class="preview-list">
+        <img *ngFor="let img of imageUrls" [src]="img" />
+      </div>
     </div>
   </div>
   <div class="actions">

--- a/front/src/app/pet/pet-form.component.scss
+++ b/front/src/app/pet/pet-form.component.scss
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-width: 900px;
+  max-width: 1100px;
   margin: auto;
 }
 
@@ -50,4 +50,27 @@
   display: flex;
   gap: 10px;
   justify-content: flex-end;
+}
+
+.preview-list {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+
+  img {
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
+    border-radius: 4px;
+  }
+}
+
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
 }

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -194,8 +194,8 @@ export class PetMapComponent implements OnInit {
   openPetForm(id?: number) {
     this.dialog
       .open(PetFormComponent, {
-        width: '90vw',
-        maxWidth: '90vw',
+        width: '95vw',
+        maxWidth: '95vw',
         data: id ? { id } : undefined
       })
       .afterClosed()


### PR DESCRIPTION
## Summary
- show uploading spinner and image previews when adding or editing a pet
- widen the Add/Edit Pet dialog

## Testing
- `npx ng build --configuration=development` *(fails: 403 Forbidden)*
- `npm test --prefix front -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfbd855848329a9be2b66acd76b58