### PR TITLE
Improve pet dialogs and markers

### DIFF
--- a/front/src/app/pet/map-icon.ts
+++ b/front/src/app/pet/map-icon.ts
@@ -1,8 +1,19 @@
 import * as L from 'leaflet';
 
-export const defaultIcon = L.icon({
-  iconUrl: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCI+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTAiIGZpbGw9InJlZCIvPjwvc3ZnPg==',
+export const lostIcon = L.icon({
+  iconUrl:
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48cGF0aCBkPSJNMTIgMkM3LjU4IDIgNCA1LjU4IDQgMTBjMCA1LjI1IDUuOTIgMTEuNzQgNy40NCAxMy4zM2ExIDEgMCAwIDAgMS4xMiAwQzE0LjA4IDIxLjc0IDIwIDE1LjI1IDIwIDEwYzAtNC40Mi0zLjU4LTgtOC04eiIgZmlsbD0icmVkIi8+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMCIgcj0iMyIgZmlsbD0id2hpdGUiLz48L3N2Zz4=',
   iconSize: [24, 24],
-  iconAnchor: [12, 12],
-  popupAnchor: [0, -12]
+  iconAnchor: [12, 24],
+  popupAnchor: [0, -24]
 });
+
+export const foundIcon = L.icon({
+  iconUrl:
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48cGF0aCBkPSJNMTIgMkM3LjU4IDIgNCA1LjU4IDQgMTBjMCA1LjI1IDUuOTIgMTEuNzQgNy40NCAxMy4zM2ExIDEgMCAwIDAgMS4xMiAwQzE0LjA4IDIxLjc0IDIwIDE1LjI1IDIwIDEwYzAtNC40Mi0zLjU4LTgtOC04eiIgZmlsbD0iYmx1ZSIvPjxjaXJjbGUgY3g9IjEyIiBjeT0iMTAiIHI9IjMiIGZpbGw9IndoaXRlIi8+PC9zdmc+',
+  iconSize: [24, 24],
+  iconAnchor: [12, 24],
+  popupAnchor: [0, -24]
+});
+
+export const defaultIcon = lostIcon;

--- a/front/src/app/pet/my-pets-dialog.component.html
+++ b/front/src/app/pet/my-pets-dialog.component.html
@@ -17,7 +17,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let p of data.pets">
+        <tr *ngFor="let p of data.pets" [class.deleted]="p.deleted">
           <td>
             <img *ngIf="p.images?.length" [src]="p.images?.[0]" width="50" />
           </td>
@@ -30,8 +30,8 @@
           <td>{{ p.observation }}</td>
           <td>{{ p.phone }}</td>
           <td>
-            <button mat-button color="primary" (click)="edit(p)">{{ 'PET.EDIT' | translate }}</button>
-            <button mat-button color="warn" (click)="remove(p)">{{ 'PET.REMOVE' | translate }}</button>
+            <button mat-button color="primary" (click)="edit(p)" [disabled]="p.deleted">{{ 'PET.EDIT' | translate }}</button>
+            <button mat-button color="warn" (click)="remove(p)" [disabled]="p.deleted">{{ 'PET.REMOVE' | translate }}</button>
           </td>
         </tr>
       </tbody>

--- a/front/src/app/pet/my-pets-dialog.component.scss
+++ b/front/src/app/pet/my-pets-dialog.component.scss
@@ -8,3 +8,20 @@ table.my-pets td {
   text-align: center;
   padding: 4px;
 }
+
+table.my-pets tr.deleted {
+  position: relative;
+}
+
+table.my-pets tr.deleted::after {
+  content: 'Registros removidos';
+  position: absolute;
+  inset: 0;
+  background: rgba(240, 240, 240, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #555;
+  pointer-events: none;
+}

--- a/front/src/app/pet/my-pets-dialog.component.ts
+++ b/front/src/app/pet/my-pets-dialog.component.ts
@@ -33,7 +33,7 @@ export class MyPetsDialogComponent {
   remove(p: PetReport) {
     if (!p.id) return;
     this.service.delete(p.id).subscribe(() => {
-      this.data.pets = this.data.pets.filter(m => m.id !== p.id);
+      p.deleted = true;
     });
   }
 

--- a/front/src/app/pet/pet-form.component.scss
+++ b/front/src/app/pet/pet-form.component.scss
@@ -5,6 +5,9 @@
   gap: 10px;
   max-width: 1100px;
   margin: auto;
+  padding: 16px;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .close-btn {

--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -11,48 +11,6 @@
   gap: 10px;
 }
 
-.img-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.8);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 100000;
-
-  .img-card {
-    position: relative;
-    width: 80vw;
-    max-width: 80vw;
-    max-height: 80vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-
-  .close-btn {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    background: none;
-    border: none;
-    color: #fff;
-    font-size: 24px;
-    cursor: pointer;
-    z-index: 1;
-  }
-
-  img {
-    width: 100%;
-    height: auto;
-    max-height: 80vh;
-    object-fit: contain;
-    border: 4px solid #fff;
-  }
-}
 
 .pet-popup {
   max-width: 260px;
@@ -68,7 +26,6 @@
     height: 260px;
     object-fit: cover;
     border-radius: 8px;
-    cursor: pointer;
     margin-bottom: 8px;
   }
 

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import * as L from 'leaflet';
-import { defaultIcon } from './map-icon';
+import { lostIcon, foundIcon } from './map-icon';
 import Supercluster from 'supercluster';
 import { PetService, PetReport } from './pet.service';
 import { RouterModule } from '@angular/router';
@@ -139,7 +139,8 @@ export class PetMapComponent implements OnInit {
         this.clusterLayer.addLayer(marker);
       } else {
         const pet = (c.properties as any).pet as PetReport;
-        const marker = L.marker([lat, lng], { icon: defaultIcon });
+        const icon = pet.status === 'FOUND' ? foundIcon : lostIcon;
+        const marker = L.marker([lat, lng], { icon });
         const popupHost = document.createElement('div');
         const compRef = this.vcr.createComponent(PetPopupComponent, {
           environmentInjector: this.injector

--- a/front/src/app/pet/pet-popup.component.html
+++ b/front/src/app/pet/pet-popup.component.html
@@ -1,5 +1,5 @@
 <div class="popup-card">
-  <img *ngIf="pet.images?.length" [src]="pet.images?.[0]" class="popup-img" (click)="openImage(pet.images?.[0])" />
+  <img *ngIf="pet.images?.length" [src]="pet.images?.[0]" class="popup-img" />
   <div class="popup-info-card">
     <div class="info-item" *ngIf="pet.name"><span class="label">{{ 'PET.NAME' | translate }}:</span> {{ pet.name }}</div>
     <div class="info-item" *ngIf="pet.date"><span class="label">{{ 'PET.DATE' | translate }}:</span> {{ pet.date | date:'dd/MM/yyyy' }}</div>

--- a/front/src/app/pet/pet-popup.component.scss
+++ b/front/src/app/pet/pet-popup.component.scss
@@ -9,7 +9,6 @@
   height: 260px;
   object-fit: cover;
   border-radius: 8px;
-  cursor: pointer;
   margin-bottom: 8px;
 }
 

--- a/front/src/app/pet/pet-popup.component.ts
+++ b/front/src/app/pet/pet-popup.component.ts
@@ -12,24 +12,4 @@ import { PetReport } from './pet.service';
 })
 export class PetPopupComponent {
   @Input() pet!: PetReport;
-
-  openImage(src?: string) {
-    if (!src) return;
-    const existing = document.querySelector('.img-overlay');
-    if (existing) existing.remove();
-
-    const overlay = document.createElement('div');
-    overlay.className = 'img-overlay';
-    overlay.innerHTML = `
-      <div class="mat-card img-card">
-        <button class="close-btn material-icons">close</button>
-        <img src="${src}" />
-      </div>`;
-    const btn = overlay.querySelector('.close-btn') as HTMLButtonElement;
-    btn.addEventListener('click', () => overlay.remove());
-    overlay.addEventListener('click', e => {
-      if (e.target === overlay) overlay.remove();
-    });
-    document.body.appendChild(overlay);
-  }
 }

--- a/front/src/app/pet/pet.service.ts
+++ b/front/src/app/pet/pet.service.ts
@@ -16,6 +16,7 @@ export interface PetReport {
   latitude?: number;
   longitude?: number;
   images?: string[];
+  deleted?: boolean;
 }
 
 @Injectable({ providedIn: 'root' })


### PR DESCRIPTION
## Summary
- add padding and scrolling to the pet form for mobile
- remove popup image zoom feature
- show removed records with a grey overlay and disable actions
- color markers red or blue based on status

## Testing
- `npm test` *(fails: ng not found)*
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfee5b3b48329aca9a8077c50b7e8