### PR TITLE
Adjust pet form UI and marker color

### DIFF
--- a/front/src/app/pet/pet-form.component.html
+++ b/front/src/app/pet/pet-form.component.html
@@ -50,6 +50,7 @@
       <div id="selectMap" class="map"></div>
       <div class="coords">Lat: {{form.value.latitude}} - Lng: {{form.value.longitude}}</div>
 
+      <label class="images-label">{{ 'PET.IMAGES' | translate }}</label>
       <input type="file" multiple (change)="onFile($event)" />
       <div class="preview-list">
         <img *ngFor="let img of imageUrls" [src]="img" />

--- a/front/src/app/pet/pet-form.component.scss
+++ b/front/src/app/pet/pet-form.component.scss
@@ -55,17 +55,23 @@
   justify-content: flex-end;
 }
 
-.preview-list {
-  display: flex;
-  gap: 8px;
-  margin-top: 8px;
+  .preview-list {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
 
-  img {
-    width: 80px;
-    height: 80px;
-    object-fit: cover;
-    border-radius: 4px;
+    img {
+      width: 120px;
+      height: 150px;
+      object-fit: cover;
+      border-radius: 4px;
+    }
   }
+
+.images-label {
+  font-weight: 600;
+  display: block;
+  margin: 8px 0 4px;
 }
 
 .loading-overlay {

--- a/front/src/app/pet/pet-form.component.ts
+++ b/front/src/app/pet/pet-form.component.ts
@@ -5,7 +5,7 @@ import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { PetService } from './pet.service';
 import * as L from 'leaflet';
-import { defaultIcon } from './map-icon';
+import { lostIcon, foundIcon } from './map-icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
@@ -43,6 +43,10 @@ export class PetFormComponent implements OnInit, AfterViewInit {
   private marker?: L.Marker;
   private pendingCoords?: L.LatLngTuple;
 
+  private getCurrentIcon(): L.Icon {
+    return this.form?.value.status === 'FOUND' ? foundIcon : lostIcon;
+  }
+
   id?: number;
 
   constructor(
@@ -65,6 +69,7 @@ export class PetFormComponent implements OnInit, AfterViewInit {
       latitude: [null, Validators.required],
       longitude: [null, Validators.required]
     });
+    this.form.get('status')!.valueChanges.subscribe(() => this.updateMarkerIcon());
     if (data && data.id) {
       this.id = data.id;
     }
@@ -116,8 +121,14 @@ export class PetFormComponent implements OnInit, AfterViewInit {
     if(this.map && this.pendingCoords){
       const [lat, lng] = this.pendingCoords;
       this.pendingCoords = undefined;
-      this.marker = L.marker([lat, lng], { icon: defaultIcon }).addTo(this.map);
+      this.marker = L.marker([lat, lng], { icon: this.getCurrentIcon() }).addTo(this.map);
       this.map.setView([lat, lng], 13);
+    }
+  }
+
+  private updateMarkerIcon(){
+    if(this.marker){
+      this.marker.setIcon(this.getCurrentIcon());
     }
   }
 
@@ -125,7 +136,7 @@ export class PetFormComponent implements OnInit, AfterViewInit {
     if(this.marker){
       this.map!.removeLayer(this.marker);
     }
-    this.marker = L.marker(ev.latlng, { icon: defaultIcon }).addTo(this.map!);
+    this.marker = L.marker(ev.latlng, { icon: this.getCurrentIcon() }).addTo(this.map!);
     this.form.patchValue({
       latitude: ev.latlng.lat,
       longitude: ev.latlng.lng

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -93,6 +93,7 @@
         "ADD": "Add pet",
         "MY_RECORDS": "My records",
         "IMAGE": "Image",
+        "IMAGES": "Images",
         "STATUS": "Status",
         "NAME": "Name",
         "DATE": "Date",

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -100,6 +100,7 @@
       "ADD": "Adicionar pet",
       "MY_RECORDS": "Meus registros",
       "IMAGE": "Imagem",
+      "IMAGES": "Imagens",
       "STATUS": "Status",
       "NAME": "Nome",
       "DATE": "Data",


### PR DESCRIPTION
## Summary
- show translated `Imagens` label for file input
- enlarge preview images in pet form
- keep marker icon color based on pet status in edit popup
- add `IMAGES` translation in both locales

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e01763af88329924e5dcfe608697a