### PR TITLE
Add contribute modal, how-to-use video and footer

### DIFF
--- a/front/src/app/app.component.ts
+++ b/front/src/app/app.component.ts
@@ -1,14 +1,18 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { HeaderComponent } from './shared/header/header.component';
+import { FooterComponent } from './shared/footer/footer.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet,
-    HeaderComponent
+  imports: [
+    RouterOutlet,
+    HeaderComponent,
+    FooterComponent
   ],
   template: `<app-header></app-header>
-<router-outlet></router-outlet>`,
+<router-outlet></router-outlet>
+<app-footer></app-footer>`,
   styleUrl: './app.component.scss'
 })
 export class AppComponent {

--- a/front/src/app/pet/pet-form.component.html
+++ b/front/src/app/pet/pet-form.component.html
@@ -51,8 +51,9 @@
       <div class="coords">Lat: {{form.value.latitude}} - Lng: {{form.value.longitude}}</div>
 
       <label class="images-label">{{ 'PET.IMAGES' | translate }}</label>
-      <input type="file" multiple (change)="onFile($event)" />
+      <input type="file" multiple accept="image/*" (change)="onFile($event)" />
       <div class="preview-list">
+        <mat-progress-spinner *ngIf="imageLoading" diameter="30" mode="indeterminate"></mat-progress-spinner>
         <img *ngFor="let img of imageUrls" [src]="img" />
       </div>
     </div>

--- a/front/src/app/pet/pet-form.component.scss
+++ b/front/src/app/pet/pet-form.component.scss
@@ -61,8 +61,8 @@
     margin-top: 8px;
 
     img {
-      width: 120px;
-      height: 150px;
+      width: 110px;
+      height: 180px;
       object-fit: cover;
       border-radius: 4px;
     }

--- a/front/src/app/pet/pet-form.component.ts
+++ b/front/src/app/pet/pet-form.component.ts
@@ -39,6 +39,7 @@ export class PetFormComponent implements OnInit, AfterViewInit {
   imageUrls: string[] = [];
   private existingImages: string[] = [];
   loading = false;
+  imageLoading = false;
   private map?: L.Map;
   private marker?: L.Marker;
   private pendingCoords?: L.LatLngTuple;
@@ -145,12 +146,23 @@ export class PetFormComponent implements OnInit, AfterViewInit {
 
   onFile(event: any){
     const files: FileList = event.target.files;
-    this.images = Array.from(files).slice(0,3);
+    this.imageLoading = true;
+    this.images = Array.from(files)
+      .filter(f => f.type.startsWith('image/'))
+      .slice(0, 3);
     this.imageUrls = [...this.existingImages];
+    let remaining = this.images.length;
+    if (remaining === 0) {
+      this.imageLoading = false;
+    }
     this.images.forEach(file => {
       const reader = new FileReader();
       reader.onload = () => {
         this.imageUrls.push(reader.result as string);
+        remaining--;
+        if (remaining === 0) {
+          this.imageLoading = false;
+        }
       };
       reader.readAsDataURL(file);
     });

--- a/front/src/app/shared/contribute-dialog.component.html
+++ b/front/src/app/shared/contribute-dialog.component.html
@@ -1,0 +1,10 @@
+<h2 mat-dialog-title>{{ 'CONTRIBUTE.TITLE' | translate }}</h2>
+<mat-dialog-content class="content">
+  <p>{{ 'CONTRIBUTE.TEXT' | translate }}</p>
+  <p>{{ 'CONTRIBUTE.PIX' | translate }}: jpfurlan@hotmail.com.br</p>
+  <p>{{ 'CONTRIBUTE.BITCOIN' | translate }}:</p>
+  <p>{{ 'CONTRIBUTE.LIGHTNING' | translate }}:</p>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="close()">{{ 'COMMON.CLOSE' | translate }}</button>
+</mat-dialog-actions>

--- a/front/src/app/shared/contribute-dialog.component.scss
+++ b/front/src/app/shared/contribute-dialog.component.scss
@@ -1,0 +1,3 @@
+.content p {
+  margin-bottom: 8px;
+}

--- a/front/src/app/shared/contribute-dialog.component.ts
+++ b/front/src/app/shared/contribute-dialog.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-contribute-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, TranslateModule],
+  templateUrl: './contribute-dialog.component.html',
+  styleUrls: ['./contribute-dialog.component.scss']
+})
+export class ContributeDialogComponent {
+  constructor(public dialogRef: MatDialogRef<ContributeDialogComponent>) {}
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/front/src/app/shared/footer/footer.component.html
+++ b/front/src/app/shared/footer/footer.component.html
@@ -1,0 +1,5 @@
+<footer class="app-footer">
+  <a href="https://www.instagram.com/furlan.jp/" target="_blank" rel="noopener">
+    {{ 'FOOTER.BY' | translate }}
+  </a>
+</footer>

--- a/front/src/app/shared/footer/footer.component.scss
+++ b/front/src/app/shared/footer/footer.component.scss
@@ -1,0 +1,10 @@
+.app-footer {
+  text-align: center;
+  padding: 8px;
+  background-color: #f5f5f5;
+  border-top: 1px solid #ddd;
+}
+.app-footer a {
+  text-decoration: none;
+  color: inherit;
+}

--- a/front/src/app/shared/footer/footer.component.ts
+++ b/front/src/app/shared/footer/footer.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  templateUrl: './footer.component.html',
+  styleUrls: ['./footer.component.scss']
+})
+export class FooterComponent {}

--- a/front/src/app/shared/header/header.component.html
+++ b/front/src/app/shared/header/header.component.html
@@ -2,6 +2,8 @@
   <div class="logo">Login Boilerplate</div>
 
   <div class="right-actions">
+    <button mat-button (click)="openHowToUse()">{{ 'HOW_TO_USE.TITLE' | translate }}</button>
+    <button mat-button (click)="openContribute()">{{ 'CONTRIBUTE.TITLE' | translate }}</button>
     <a *ngIf="!loggedIn" mat-button routerLink="/login" class="login-button">{{ 'LOGIN.TITLE' | translate }}</a>
     <button *ngIf="loggedIn" mat-button (click)="logout()">Logout</button>
     <div class="lang-menu">

--- a/front/src/app/shared/header/header.component.ts
+++ b/front/src/app/shared/header/header.component.ts
@@ -5,18 +5,29 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { ContributeDialogComponent } from '../contribute-dialog.component';
+import { HowToUseDialogComponent } from '../how-to-use-dialog.component';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [CommonModule, MatMenuModule, MatButtonModule, MatIconModule, TranslateModule, RouterModule],
+  imports: [
+    CommonModule,
+    MatMenuModule,
+    MatButtonModule,
+    MatIconModule,
+    TranslateModule,
+    RouterModule,
+    MatDialogModule
+  ],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss']
 })
 export class HeaderComponent {
   currentLang!: string;
 
-  constructor(private translate: TranslateService,) {
+  constructor(private translate: TranslateService, private dialog: MatDialog) {
     this.translate.addLangs(['pt','en']);
 
     const saved = localStorage.getItem('lang');
@@ -43,5 +54,13 @@ export class HeaderComponent {
 
   logout(){
     localStorage.removeItem('accessToken');
+  }
+
+  openContribute() {
+    this.dialog.open(ContributeDialogComponent, { maxWidth: '400px' });
+  }
+
+  openHowToUse() {
+    this.dialog.open(HowToUseDialogComponent, { maxWidth: '560px' });
   }
 }

--- a/front/src/app/shared/how-to-use-dialog.component.html
+++ b/front/src/app/shared/how-to-use-dialog.component.html
@@ -1,0 +1,7 @@
+<h2 mat-dialog-title>{{ 'HOW_TO_USE.TITLE' | translate }}</h2>
+<mat-dialog-content class="content">
+  <iframe width="100%" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen></iframe>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button (click)="close()">{{ 'COMMON.CLOSE' | translate }}</button>
+</mat-dialog-actions>

--- a/front/src/app/shared/how-to-use-dialog.component.scss
+++ b/front/src/app/shared/how-to-use-dialog.component.scss
@@ -1,0 +1,5 @@
+.content {
+  iframe {
+    border: none;
+  }
+}

--- a/front/src/app/shared/how-to-use-dialog.component.ts
+++ b/front/src/app/shared/how-to-use-dialog.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-how-to-use-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, TranslateModule],
+  templateUrl: './how-to-use-dialog.component.html',
+  styleUrls: ['./how-to-use-dialog.component.scss']
+})
+export class HowToUseDialogComponent {
+  constructor(public dialogRef: MatDialogRef<HowToUseDialogComponent>) {}
+  close() { this.dialogRef.close(); }
+}

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -109,6 +109,19 @@
         ,"STATUS_LOST": "Lost"
         ,"STATUS_FOUND": "Found"
         ,"SAVE": "Save"
+      },
+      "FOOTER": {
+        "BY": "by jpfurlan"
+      },
+      "CONTRIBUTE": {
+        "TITLE": "Contribute",
+        "TEXT": "Help keep the project, servers and domain running.",
+        "PIX": "Pix Key",
+        "BITCOIN": "Bitcoin Address",
+        "LIGHTNING": "Lightning Address"
+      },
+      "HOW_TO_USE": {
+        "TITLE": "How to use"
       }
 
   }

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -116,6 +116,19 @@
       "STATUS_LOST": "Perdido",
       "STATUS_FOUND": "Encontrado",
       "SAVE": "Salvar"
+    },
+    "FOOTER": {
+      "BY": "by jpfurlan"
+    },
+    "CONTRIBUTE": {
+      "TITLE": "Contribua",
+      "TEXT": "Ajude a manter o projeto, servidores, domínio e manutenção.",
+      "PIX": "Chave Pix",
+      "BITCOIN": "Endereço Bitcoin",
+      "LIGHTNING": "Endereço Lightning"
+    },
+    "HOW_TO_USE": {
+      "TITLE": "Como usar"
     }
   }
   


### PR DESCRIPTION
## Summary
- tweak preview size for pet images
- show loader when reading image files
- restrict file input to images
- add contribute popup with Pix info
- add how-to-use popup with YouTube video
- include footer linking to Instagram
- expose new translations for internationalization

## Testing
- `npm test --silent` *(fails: ng not found)*
- `mvn -f back/pom.xml -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e05e372a88329ac748ffd32683a57