### PR TITLE
Fix email HTML issue and add localized status

### DIFF
--- a/front/src/app/pet/my-pets-dialog.component.html
+++ b/front/src/app/pet/my-pets-dialog.component.html
@@ -21,7 +21,7 @@
           <td>
             <img *ngIf="p.images?.length" [src]="p.images?.[0]" width="50" />
           </td>
-          <td>{{ p.status }}</td>
+          <td>{{ ('PET.STATUS_' + p.status) | translate }}</td>
           <td>{{ p.name }}</td>
           <td>{{ p.date | date:'dd/MM/yyyy' }}</td>
           <td>{{ p.breed }}</td>

--- a/front/src/app/pet/pet-popup.component.html
+++ b/front/src/app/pet/pet-popup.component.html
@@ -3,7 +3,7 @@
   <div class="popup-info-card">
     <div class="info-item" *ngIf="pet.name"><span class="label">{{ 'PET.NAME' | translate }}:</span> {{ pet.name }}</div>
     <div class="info-item" *ngIf="pet.date"><span class="label">{{ 'PET.DATE' | translate }}:</span> {{ pet.date | date:'dd/MM/yyyy' }}</div>
-    <div class="info-item"><span class="label">{{ 'PET.STATUS' | translate }}:</span> {{ pet.status }}</div>
+    <div class="info-item"><span class="label">{{ 'PET.STATUS' | translate }}:</span> {{ ('PET.STATUS_' + pet.status) | translate }}</div>
     <div class="info-item" *ngIf="pet.breed"><span class="label">{{ 'PET.BREED' | translate }}:</span> {{ pet.breed }}</div>
     <div class="info-item" *ngIf="pet.size"><span class="label">{{ 'PET.SIZE' | translate }}:</span> {{ pet.size }}</div>
     <div class="info-item" *ngIf="pet.color"><span class="label">{{ 'PET.COLOR' | translate }}:</span> {{ pet.color }}</div>

--- a/front/src/app/shared/contribute-dialog.component.html
+++ b/front/src/app/shared/contribute-dialog.component.html
@@ -1,7 +1,7 @@
 <h2 mat-dialog-title>{{ 'CONTRIBUTE.TITLE' | translate }}</h2>
 <mat-dialog-content class="content">
   <p>{{ 'CONTRIBUTE.TEXT' | translate }}</p>
-  <p>{{ 'CONTRIBUTE.PIX' | translate }}: jpfurlan@hotmail.com.br</p>
+  <p>{{ 'CONTRIBUTE.PIX' | translate }}: jpfurlan&#64;hotmail.com.br</p>
   <p>{{ 'CONTRIBUTE.BITCOIN' | translate }}:</p>
   <p>{{ 'CONTRIBUTE.LIGHTNING' | translate }}:</p>
 </mat-dialog-content>


### PR DESCRIPTION
## Summary
- escape `@` in contribute dialog to satisfy Angular 17 template compiler
- localize status labels on pet popup and my pets dialog

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e07b63adc8329990a26e74375c44b