### PR TITLE
Rename page and add createdAt field

### DIFF
--- a/back/src/main/java/com/securitygateway/loginboilerplate/model/pet/PetReport.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/model/pet/PetReport.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.List;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Data
 @Entity
@@ -49,5 +50,8 @@ public class PetReport {
     @Column(nullable = false, columnDefinition = "boolean default false")
     @Builder.Default
     private Boolean deleted = false;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 }
 

--- a/back/src/main/java/com/securitygateway/loginboilerplate/service/pet/PetReportService.java
+++ b/back/src/main/java/com/securitygateway/loginboilerplate/service/pet/PetReportService.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class PetReportService {
         report.setImages(paths);
         report.setUser(user);
         report.setDeleted(false);
+        report.setCreatedAt(LocalDateTime.now());
         return repository.save(report);
     }
 

--- a/back/src/main/resources/application.properties
+++ b/back/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=LoginBoilerplate
+spring.application.name=cadeopet
 server.port=8080
 spring.datasource.url = jdbc:postgresql://localhost:5432/JwtRefresh
 spring.datasource.username = postgres

--- a/front/README.md
+++ b/front/README.md
@@ -1,4 +1,4 @@
-# LoginCrudApp
+# cadeopet
 
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 19.0.4.
 

--- a/front/angular.json
+++ b/front/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "login-crud-app": {
+    "cadeopet": {
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": "dist/login-crud-app",
+            "outputPath": "dist/cadeopet",
             "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
@@ -71,10 +71,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "buildTarget": "login-crud-app:build:production"
+              "buildTarget": "cadeopet:build:production"
             },
             "development": {
-              "buildTarget": "login-crud-app:build:development"
+              "buildTarget": "cadeopet:build:development"
             }
           },
           "defaultConfiguration": "development"

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "login-crud-app",
+  "name": "cadeopet",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "login-crud-app",
+      "name": "cadeopet",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^19.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "login-crud-app",
+  "name": "cadeopet",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/front/src/app/app.component.spec.ts
+++ b/front/src/app/app.component.spec.ts
@@ -14,16 +14,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'login-crud-app' title`, () => {
+  it(`should have the 'cadeopet' title`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('login-crud-app');
+    expect(app.title).toEqual('cadeopet');
   });
 
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, login-crud-app');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, cadeopet');
   });
 });

--- a/front/src/app/app.component.ts
+++ b/front/src/app/app.component.ts
@@ -16,5 +16,5 @@ import { FooterComponent } from './shared/footer/footer.component';
   styleUrl: './app.component.scss'
 })
 export class AppComponent {
-  title = 'login-crud-app';
+  title = 'cadeopet';
 }

--- a/front/src/assets/favicon.svg
+++ b/front/src/assets/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="30" cy="30" r="12" fill="black"/>
+  <circle cx="70" cy="30" r="12" fill="black"/>
+  <circle cx="50" cy="20" r="12" fill="black"/>
+  <path d="M20 60 Q50 90 80 60 Q50 100 20 60 Z" fill="black"/>
+</svg>

--- a/front/src/index.html
+++ b/front/src/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>LoginCrudApp</title>
+  <title>Cadê o pet?</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Summary
- rename angular app to `cadeopet`
- update favicon to paw svg and page title
- record `createdAt` when creating a pet report
- rename package files to match new app name
- update Spring application name

## Testing
- `npm test` *(fails: ng not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0ad1b8208329bdcc4e44db8b9a02