### PR TITLE
Add map overlay filters

### DIFF
--- a/front/src/app/pet/pet-map.component.html
+++ b/front/src/app/pet/pet-map.component.html
@@ -1,6 +1,28 @@
-<div class="actions" *ngIf="loggedIn">
-  <button mat-raised-button color="primary" (click)="openPetForm()">{{ 'PET.ADD' | translate }}</button>
-  <button mat-raised-button color="accent" (click)="openMyPets()">{{ 'PET.MY_RECORDS' | translate }}</button>
-</div>
 <div id="map"></div>
+
+<div class="controls">
+  <div class="actions" *ngIf="loggedIn">
+    <button mat-raised-button color="primary" (click)="openPetForm()">{{ 'PET.ADD' | translate }}</button>
+    <button mat-raised-button color="accent" (click)="openMyPets()">{{ 'PET.MY_RECORDS' | translate }}</button>
+  </div>
+
+  <div class="filters">
+    <mat-form-field appearance="fill" class="filter-field">
+      <mat-label>{{ 'PET.FILTER_STATUS' | translate }}</mat-label>
+      <mat-select [(ngModel)]="statusFilter" (selectionChange)="applyFilters()">
+        <mat-option value="">{{ 'PET.ALL' | translate }}</mat-option>
+        <mat-option value="LOST">{{ 'PET.STATUS_LOST' | translate }}</mat-option>
+        <mat-option value="FOUND">{{ 'PET.STATUS_FOUND' | translate }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill" class="filter-field">
+      <mat-label>{{ 'PET.FILTER_PERIOD' | translate }}</mat-label>
+      <mat-select [(ngModel)]="periodFilter" (selectionChange)="applyFilters()">
+        <mat-option value="7">{{ 'PET.LAST_7_DAYS' | translate }}</mat-option>
+        <mat-option value="15">{{ 'PET.LAST_15_DAYS' | translate }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+</div>
 

--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -1,12 +1,26 @@
 #map {
-  height: 100vh;
+  height: calc(100vh - 64px);
   width: 100%;
   position: relative;
   z-index: 0;
 }
 
+.controls {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 1000;
+}
+
 .actions {
-  margin: 10px 0;
+  display: flex;
+  gap: 10px;
+}
+
+.filters {
   display: flex;
   gap: 10px;
 }

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -108,7 +108,12 @@
         "REMOVE": "Remove"
         ,"STATUS_LOST": "Lost"
         ,"STATUS_FOUND": "Found"
-        ,"SAVE": "Save"
+        ,"SAVE": "Save",
+        "FILTER_STATUS": "Filter Status",
+        "FILTER_PERIOD": "Period",
+        "LAST_7_DAYS": "Last 7 days",
+        "LAST_15_DAYS": "Last 15 days",
+        "ALL": "All"
       },
       "FOOTER": {
         "BY": "by jpfurlan"

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -115,7 +115,12 @@
       "REMOVE": "Remover",
       "STATUS_LOST": "Perdido",
       "STATUS_FOUND": "Encontrado",
-      "SAVE": "Salvar"
+      "SAVE": "Salvar",
+      "FILTER_STATUS": "Filtrar Status",
+      "FILTER_PERIOD": "Período",
+      "LAST_7_DAYS": "Últimos 7 dias",
+      "LAST_15_DAYS": "Últimos 15 dias",
+      "ALL": "Todos"
     },
     "FOOTER": {
       "BY": "by jpfurlan"


### PR DESCRIPTION
## Summary
- overlay action buttons on the map
- add status/period filters on the map
- update map height to avoid scrollbar
- provide translations for new filter texts

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0ddd733c83299c46401da1bf271f