### PR TITLE
Fix map filtering and overlay

### DIFF
--- a/front/src/app/pet/pet-map.component.html
+++ b/front/src/app/pet/pet-map.component.html
@@ -1,28 +1,32 @@
-<div id="map"></div>
+<div id="map">
+  <div class="controls">
+    <div class="filters-box">
+      <div class="filters-title">{{ 'PET.FILTERS_TITLE' | translate }}</div>
+      <div class="filters">
+        <mat-form-field appearance="fill" class="filter-field">
+          <mat-label>{{ 'PET.FILTER_STATUS' | translate }}</mat-label>
+          <mat-select [(ngModel)]="statusFilter" (selectionChange)="applyFilters()">
+            <mat-option value="">{{ 'PET.ALL' | translate }}</mat-option>
+            <mat-option value="LOST">{{ 'PET.STATUS_LOST' | translate }}</mat-option>
+            <mat-option value="FOUND">{{ 'PET.STATUS_FOUND' | translate }}</mat-option>
+          </mat-select>
+        </mat-form-field>
 
-<div class="controls">
-  <div class="actions" *ngIf="loggedIn">
-    <button mat-raised-button color="primary" (click)="openPetForm()">{{ 'PET.ADD' | translate }}</button>
-    <button mat-raised-button color="accent" (click)="openMyPets()">{{ 'PET.MY_RECORDS' | translate }}</button>
-  </div>
+        <mat-form-field appearance="fill" class="filter-field">
+          <mat-label>{{ 'PET.FILTER_PERIOD' | translate }}</mat-label>
+          <mat-select [(ngModel)]="periodFilter" (selectionChange)="applyFilters()">
+            <mat-option value="">{{ 'PET.ALL' | translate }}</mat-option>
+            <mat-option value="7">{{ 'PET.LAST_7_DAYS' | translate }}</mat-option>
+            <mat-option value="15">{{ 'PET.LAST_15_DAYS' | translate }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+    </div>
 
-  <div class="filters">
-    <mat-form-field appearance="fill" class="filter-field">
-      <mat-label>{{ 'PET.FILTER_STATUS' | translate }}</mat-label>
-      <mat-select [(ngModel)]="statusFilter" (selectionChange)="applyFilters()">
-        <mat-option value="">{{ 'PET.ALL' | translate }}</mat-option>
-        <mat-option value="LOST">{{ 'PET.STATUS_LOST' | translate }}</mat-option>
-        <mat-option value="FOUND">{{ 'PET.STATUS_FOUND' | translate }}</mat-option>
-      </mat-select>
-    </mat-form-field>
-
-    <mat-form-field appearance="fill" class="filter-field">
-      <mat-label>{{ 'PET.FILTER_PERIOD' | translate }}</mat-label>
-      <mat-select [(ngModel)]="periodFilter" (selectionChange)="applyFilters()">
-        <mat-option value="7">{{ 'PET.LAST_7_DAYS' | translate }}</mat-option>
-        <mat-option value="15">{{ 'PET.LAST_15_DAYS' | translate }}</mat-option>
-      </mat-select>
-    </mat-form-field>
+    <div class="actions" *ngIf="loggedIn">
+      <button mat-raised-button color="primary" (click)="openPetForm()">{{ 'PET.ADD' | translate }}</button>
+      <button mat-raised-button color="accent" (click)="openMyPets()">{{ 'PET.MY_RECORDS' | translate }}</button>
+    </div>
   </div>
 </div>
 

--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -15,6 +15,19 @@
   z-index: 1000;
 }
 
+.filters-box {
+  background: rgba(255, 255, 255, 0.9);
+  padding: 8px;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.filters-title {
+  font-weight: bold;
+}
+
 .actions {
   display: flex;
   gap: 10px;

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -43,7 +43,7 @@ export class PetMapComponent implements OnInit {
   private myPetsDialog?: MatDialogRef<MyPetsDialogComponent>;
 
   statusFilter: string = '';
-  periodFilter: number = 7;
+  periodFilter: number | '' = '';
 
   constructor(
     private service: PetService,
@@ -169,9 +169,9 @@ export class PetMapComponent implements OnInit {
     if(this.statusFilter){
       filtered = filtered.filter(p => p.status === this.statusFilter);
     }
-    if(this.periodFilter){
+    if(this.periodFilter !== ''){
       const limit = new Date();
-      limit.setDate(limit.getDate() - this.periodFilter);
+      limit.setDate(limit.getDate() - +this.periodFilter);
       filtered = filtered.filter(p => {
         return p.date ? new Date(p.date) >= limit : false;
       });

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -109,6 +109,7 @@
         ,"STATUS_LOST": "Lost"
         ,"STATUS_FOUND": "Found"
         ,"SAVE": "Save",
+        "FILTERS_TITLE": "Filters",
         "FILTER_STATUS": "Filter Status",
         "FILTER_PERIOD": "Period",
         "LAST_7_DAYS": "Last 7 days",

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -116,6 +116,7 @@
       "STATUS_LOST": "Perdido",
       "STATUS_FOUND": "Encontrado",
       "SAVE": "Salvar",
+      "FILTERS_TITLE": "Filtros",
       "FILTER_STATUS": "Filtrar Status",
       "FILTER_PERIOD": "Período",
       "LAST_7_DAYS": "Últimos 7 dias",


### PR DESCRIPTION
## Summary
- display all pets by default by removing period filter
- add internationalized title for filters
- move filter controls over the map
- style filter box

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0f8bffb88329a088627381398258