### PR TITLE
Improve styling and fix datepicker provider

### DIFF
--- a/front/src/app/app.config.ts
+++ b/front/src/app/app.config.ts
@@ -8,6 +8,7 @@ import { HttpClient } from '@angular/common/http';
 import { routes } from './app.routes';
 import { authInterceptor } from './core/auth.interceptor';
 import { provideNgxMask } from 'ngx-mask';
+import { MatNativeDateModule } from '@angular/material/core';
 
 export function HttpLoaderFactory(http: HttpClient) {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -20,6 +21,7 @@ export const appConfig: ApplicationConfig = {
     provideAnimations(),
     provideNgxMask(),
     importProvidersFrom(
+      MatNativeDateModule,
       TranslateModule.forRoot({
         loader: {
           provide: TranslateLoader,

--- a/front/src/app/auth/register/register.component.ts
+++ b/front/src/app/auth/register/register.component.ts
@@ -15,6 +15,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { AlertService } from '../../shared/alert.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { RegisterRequest, Gender } from '../../models/register-request.model';
+import { NgxMaskDirective } from 'ngx-mask';
 
 @Component({
   selector: 'app-register',
@@ -31,7 +32,8 @@ import { RegisterRequest, Gender } from '../../models/register-request.model';
     RouterModule,
     MatProgressSpinnerModule,
     MatDialogModule,
-    TranslateModule
+    TranslateModule,
+    NgxMaskDirective
   ],
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss'],

--- a/front/src/app/pet/pet-form.component.ts
+++ b/front/src/app/pet/pet-form.component.ts
@@ -14,6 +14,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
+import { NgxMaskDirective } from 'ngx-mask';
 import { TranslateModule } from '@ngx-translate/core';
 import { finalize } from 'rxjs/operators';
 
@@ -32,7 +33,8 @@ import { finalize } from 'rxjs/operators';
     MatProgressSpinnerModule,
     MatDatepickerModule,
     MatNativeDateModule,
-    TranslateModule
+    TranslateModule,
+    NgxMaskDirective
   ],
   templateUrl: './pet-form.component.html',
   styleUrls: ['./pet-form.component.scss']

--- a/front/src/app/pet/pet-map.component.html
+++ b/front/src/app/pet/pet-map.component.html
@@ -18,6 +18,7 @@
             <mat-option value="">{{ 'PET.ALL' | translate }}</mat-option>
             <mat-option value="7">{{ 'PET.LAST_7_DAYS' | translate }}</mat-option>
             <mat-option value="15">{{ 'PET.LAST_15_DAYS' | translate }}</mat-option>
+            <mat-option value="30">{{ 'PET.LAST_30_DAYS' | translate }}</mat-option>
           </mat-select>
         </mat-form-field>
       </div>

--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -8,7 +8,7 @@
 .controls {
   position: absolute;
   top: 10px;
-  left: 10px;
+  right: 10px;
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/front/src/app/shared/footer/footer.component.scss
+++ b/front/src/app/shared/footer/footer.component.scss
@@ -1,10 +1,10 @@
 .app-footer {
   text-align: center;
   padding: 8px;
-  background-color: #f5f5f5;
+  background-color: var(--background-color);
   border-top: 1px solid #ddd;
 }
 .app-footer a {
   text-decoration: none;
-  color: inherit;
+  color: var(--primary-color);
 }

--- a/front/src/app/shared/header/header.component.html
+++ b/front/src/app/shared/header/header.component.html
@@ -1,5 +1,5 @@
 <header class="app-header">
-  <div class="logo">Login Boilerplate</div>
+  <div class="logo">Cadê o Pet?</div>
 
   <div class="right-actions">
     <button mat-button (click)="openHowToUse()">{{ 'HOW_TO_USE.TITLE' | translate }}</button>

--- a/front/src/app/shared/header/header.component.scss
+++ b/front/src/app/shared/header/header.component.scss
@@ -1,16 +1,16 @@
 .app-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 2rem;
-    background-color: #f5f5f5;
-    border-bottom: 1px solid #ddd;
-  }
-  .logo {
-    font-size: 1.25rem;
-    font-weight: bold;
-    color: #333;
-  }
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
 .lang-menu {
   display: flex;
   align-items: center;
@@ -20,8 +20,10 @@
   align-items: center;
   gap: 1rem;
 }
+
 .login-button {
   text-transform: none;
+  color: #fff;
 }
   .lang-button {
     text-transform: none;
@@ -30,3 +32,7 @@
   .lang-button mat-icon {
     vertical-align: middle;
   }
+
+button.mat-button {
+  color: #fff;
+}

--- a/front/src/assets/i18n/en.json
+++ b/front/src/assets/i18n/en.json
@@ -114,6 +114,7 @@
         "FILTER_PERIOD": "Period",
         "LAST_7_DAYS": "Last 7 days",
         "LAST_15_DAYS": "Last 15 days",
+        "LAST_30_DAYS": "Last 30 days",
         "ALL": "All"
       },
       "FOOTER": {

--- a/front/src/assets/i18n/pt.json
+++ b/front/src/assets/i18n/pt.json
@@ -121,6 +121,7 @@
       "FILTER_PERIOD": "Período",
       "LAST_7_DAYS": "Últimos 7 dias",
       "LAST_15_DAYS": "Últimos 15 dias",
+      "LAST_30_DAYS": "Últimos 30 dias",
       "ALL": "Todos"
     },
     "FOOTER": {

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -1,7 +1,15 @@
 /* You can add global styles to this file, and also import other style files */
 
+:root {
+  --primary-color: #1976d2;
+  --accent-color: #4caf50;
+  --background-color: #f5f5f5;
+  --text-color: #333;
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+}
+
 html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+body { margin: 0; background: var(--background-color); color: var(--text-color); }
 @import "leaflet/dist/leaflet.css";
 /* Esconde o reveal do Edge/IE */
 input[type="password"]::-ms-reveal,


### PR DESCRIPTION
## Summary
- make header show **Cadê o Pet?**
- modernize overall styles and add CSS variables
- shift map filters to the right and add 30-day filter option
- provide `MatNativeDateModule` globally for datepicker
- enable phone mask directive on pet form and register form

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e13fd542883298804dd6619007c0e