### PR TITLE
Update header actions and layout

### DIFF
--- a/front/src/app/pet/pet-map.component.html
+++ b/front/src/app/pet/pet-map.component.html
@@ -24,9 +24,9 @@
       </div>
     </div>
 
-    <div class="actions" *ngIf="loggedIn">
-      <button mat-raised-button color="primary" (click)="openPetForm()">{{ 'PET.ADD' | translate }}</button>
-      <button mat-raised-button color="accent" (click)="openMyPets()">{{ 'PET.MY_RECORDS' | translate }}</button>
+    <div class="actions">
+      <button mat-raised-button color="primary" (click)="handleAddPet()">{{ 'PET.ADD' | translate }}</button>
+      <button mat-raised-button color="accent" *ngIf="loggedIn" (click)="openMyPets()">{{ 'PET.MY_RECORDS' | translate }}</button>
     </div>
   </div>
 </div>

--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -1,5 +1,5 @@
 #map {
-  height: calc(100vh - 64px);
+  height: calc(100vh - 104px);
   width: 100%;
   position: relative;
   z-index: 0;

--- a/front/src/app/pet/pet-map.component.ts
+++ b/front/src/app/pet/pet-map.component.ts
@@ -4,7 +4,7 @@ import * as L from 'leaflet';
 import { lostIcon, foundIcon } from './map-icon';
 import Supercluster from 'supercluster';
 import { PetService, PetReport } from './pet.service';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -50,7 +50,8 @@ export class PetMapComponent implements OnInit {
     private translate: TranslateService,
     private dialog: MatDialog,
     private vcr: ViewContainerRef,
-    private injector: EnvironmentInjector
+    private injector: EnvironmentInjector,
+    private router: Router
   ) {}
 
   get loggedIn(): boolean {
@@ -218,6 +219,14 @@ export class PetMapComponent implements OnInit {
         },
         error: () => {}
       });
+    }
+  }
+
+  handleAddPet() {
+    if (this.loggedIn) {
+      this.openPetForm();
+    } else {
+      this.router.navigate(['/login']);
     }
   }
 

--- a/front/src/app/shared/header/header.component.scss
+++ b/front/src/app/shared/header/header.component.scss
@@ -3,8 +3,8 @@
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
-  background-color: var(--primary-color);
-  color: #fff;
+  background-color: #f5f5f5;
+  color: var(--text-color);
 }
 
 .logo {
@@ -23,7 +23,7 @@
 
 .login-button {
   text-transform: none;
-  color: #fff;
+  color: var(--primary-color);
 }
   .lang-button {
     text-transform: none;
@@ -34,5 +34,5 @@
   }
 
 button.mat-button {
-  color: #fff;
+  color: var(--text-color);
 }


### PR DESCRIPTION
## Summary
- always show the "Add pet" button
- hide "My records" when not logged in
- redirect to login when trying to add a pet while logged out
- change header background to light grey
- increase map height so page has no scrollbar

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e162961848329a606fe5112af8478