### PR TITLE
Fix mobile filter layout

### DIFF
--- a/front/src/app/pet/pet-map.component.scss
+++ b/front/src/app/pet/pet-map.component.scss
@@ -38,6 +38,22 @@
   gap: 10px;
 }
 
+@media (max-width: 600px) {
+  .filters {
+    flex-direction: column;
+    .filter-field {
+      width: 100%;
+    }
+  }
+
+  .actions {
+    flex-direction: column;
+    button {
+      width: 100%;
+    }
+  }
+}
+
 
 .pet-popup {
   max-width: 260px;


### PR DESCRIPTION
## Summary
- stack filter dropdowns vertically on narrow screens
- stack action buttons vertically on narrow screens

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e19e29cec8329a86cde14eb67afce